### PR TITLE
feat(order/export): implement admin CSV export and signed-url storage (closes Issue #6)

### DIFF
--- a/docs/CSV_EXPORT_FEATURE.md
+++ b/docs/CSV_EXPORT_FEATURE.md
@@ -1,0 +1,255 @@
+# CSV Export Feature - Admin Orders Export
+
+## Overview
+This feature allows administrators to export order and donation data as CSV files for grant reporting and compliance purposes. The exported CSV includes order details, donation amounts, and status information within a specified date range.
+
+## Files Added/Modified
+
+### New Files:
+1. **`src/shared/middleware/adminMiddleware.ts`** - Admin authorization middleware
+2. **`src/modules/order/controllers/exportController.ts`** - CSV export controller
+3. **`src/modules/order/routes/adminRoutes.ts`** - Admin routes definition
+4. **`src/modules/order/tests/exportRoutes.test.ts`** - Comprehensive test suite
+
+### Modified Files:
+1. **`src/modules/order/model/Order.ts`** - Added optional `email` and `status` fields
+2. **`src/modules/order/repositories/OrderRepository.ts`** - Added `getOrdersByDateRange()` method
+3. **`src/app.ts`** - Registered admin routes
+4. **`package.json`** - Added `fast-csv` dependency
+
+## API Endpoint
+
+### Export Orders CSV
+```
+GET /api/admin/export/orders?start_date=YYYY-MM-DD&end_date=YYYY-MM-DD
+```
+
+**Authentication:** Required (Bearer token with admin privileges)
+
+**Query Parameters:**
+- `start_date` (required): Start date in YYYY-MM-DD format (inclusive)
+- `end_date` (required): End date in YYYY-MM-DD format (inclusive)
+
+**Response:**
+```json
+{
+  "success": true,
+  "message": "CSV export generated successfully",
+  "data": {
+    "url": "https://storage.googleapis.com/...",
+    "filename": "exports/orders_2024-01-01_to_2024-12-31_2024-11-07T12-30-45-123Z.csv",
+    "recordCount": 150,
+    "dateRange": {
+      "start": "2024-01-01",
+      "end": "2024-12-31"
+    },
+    "expiresIn": "1 hour"
+  },
+  "timestamp": "2024-11-07T12:30:45.123Z"
+}
+```
+
+## CSV Format
+
+The exported CSV contains the following columns:
+
+| Column | Description | Example |
+|--------|-------------|---------|
+| Order ID | Unique order identifier | `abc123def456` |
+| User ID | Firebase user ID | `user_xyz789` |
+| Email | User's email address | `user@example.com` |
+| Items Donated | Product name or items | `Winter Coat` |
+| Donation Amount (£) | Amount in pounds | `50.00` |
+| Date of Order/Donation | ISO timestamp | `2024-06-15T10:30:00.000Z` |
+| Status | Order status | `completed`, `pending`, or `failed` |
+
+## Admin Setup
+
+### Setting Admin Privileges
+
+To grant admin privileges to a user, you need to set custom claims using Firebase Admin SDK:
+
+```typescript
+import { admin } from './src/shared/config/firebaseConfig';
+
+// Grant admin access to a user
+async function setAdminClaim(uid: string) {
+  await admin.auth().setCustomUserClaims(uid, { admin: true });
+  console.log(`Admin privileges granted to user: ${uid}`);
+}
+
+// Usage
+setAdminClaim('user-firebase-uid');
+```
+
+**Note:** After setting custom claims, the user needs to refresh their authentication token for the changes to take effect.
+
+### Verifying Admin Status
+
+Users can verify their admin status by decoding their Firebase ID token. The token will contain:
+```json
+{
+  "uid": "user-firebase-uid",
+  "email": "admin@example.com",
+  "admin": true
+}
+```
+
+## Security Features
+
+1. **Two-Level Authentication:**
+   - First level: `authMiddleware` validates Firebase ID token
+   - Second level: `adminMiddleware` checks for admin custom claim
+
+2. **Secure File Storage:**
+   - CSV files are stored in Firebase Storage (private bucket)
+   - Signed URLs with 1-hour expiration
+   - Files stored in `exports/` directory
+
+3. **Input Validation:**
+   - Date format validation (YYYY-MM-DD)
+   - Date range validation (start must be <= end)
+   - Required parameter checks
+
+## Environment Configuration
+
+Ensure the following environment variable is set:
+
+```env
+FIREBASE_STORAGE_BUCKET=your-project.appspot.com
+```
+
+## Testing
+
+Run the comprehensive test suite:
+
+```bash
+npm test -- exportRoutes.test.ts
+```
+
+The test suite covers:
+- Authentication and authorization
+- Input validation
+- CSV generation with various data scenarios
+- Error handling
+- Empty result sets
+
+## Usage Examples
+
+### Example 1: Export Orders for Q1 2024
+```bash
+curl -X GET "http://localhost:4000/api/admin/export/orders?start_date=2024-01-01&end_date=2024-03-31" \
+  -H "Authorization: Bearer YOUR_ADMIN_TOKEN"
+```
+
+### Example 2: Export Orders for Specific Month
+```bash
+curl -X GET "http://localhost:4000/api/admin/export/orders?start_date=2024-06-01&end_date=2024-06-30" \
+  -H "Authorization: Bearer YOUR_ADMIN_TOKEN"
+```
+
+### Example 3: Using Postman
+1. Method: GET
+2. URL: `http://localhost:4000/api/admin/export/orders`
+3. Params:
+   - `start_date`: `2024-01-01`
+   - `end_date`: `2024-12-31`
+4. Headers:
+   - `Authorization`: `Bearer YOUR_ADMIN_TOKEN`
+
+## Error Handling
+
+### Common Errors:
+
+**401 Unauthorized:**
+```json
+{
+  "success": false,
+  "message": "Authorization header is required",
+  "error": "Missing or invalid Bearer token"
+}
+```
+
+**403 Forbidden:**
+```json
+{
+  "success": false,
+  "message": "Admin access required",
+  "error": "User does not have admin privileges"
+}
+```
+
+**400 Bad Request:**
+```json
+{
+  "success": false,
+  "message": "Invalid date format",
+  "error": "Dates must be in YYYY-MM-DD format"
+}
+```
+
+**500 Internal Server Error:**
+```json
+{
+  "success": false,
+  "message": "Export failed",
+  "error": "Detailed error message"
+}
+```
+
+## Acceptance Criteria Verification
+
+✅ **Admin Authentication**: Only users with admin custom claims can access the endpoint
+✅ **Date Range Filtering**: Orders are filtered by the specified date range (inclusive)
+✅ **CSV Headers**: CSV always includes headers, even when no data exists
+✅ **Status Tracking**: Failed/pending orders are marked with appropriate status
+✅ **Secure Download**: Signed URLs expire after 1 hour
+✅ **Empty Results**: Empty date ranges return CSV with headers only
+
+## Performance Considerations (For Future)
+
+- **Small Datasets (< 1000 records)**: Response time < 5 seconds
+- **Medium Datasets (1000-10000 records)**: Response time 5-30 seconds
+- **Large Datasets (> 10000 records)**: Consider implementing pagination or async job processing
+
+For very large exports, can consider:
+1. Implementing batch processing
+2. Using Cloud Functions for background processing
+3. Emailing download links when ready
+
+## Maintenance
+
+### Storage Cleanup
+
+Firebase Storage lifecycle rules can be configured to auto-delete old export files:
+
+1. Go to Firebase Console → Storage
+2. Create lifecycle rule:
+   - Condition: Age > 7 days
+   - Action: Delete
+   - Prefix: `exports/`
+
+### Monitoring
+
+Monitor these metrics:
+- Export request frequency
+- Average export size
+- Failed export attempts
+- Storage usage in `exports/` directory
+
+## Support
+
+For issues or questions:
+1. Check the logs for detailed error messages
+2. Verify Firebase Storage configuration
+3. Confirm admin custom claims are properly set
+4. Review the test suite for usage examples
+
+## Future Enhancements
+
+Potential improvements:
+1. Add filters for status, user ID, or product
+2. Support multiple export formats (Excel, JSON)
+3. Schedule automated exports
+4. Email notifications with download links
+5. Audit logging for export requests

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "cross-env": "^7.0.3",
     "dotenv": "^16.5.0",
     "express": "^4.19.2",
+    "fast-csv": "^5.0.5",
     "firebase": "^11.10.0",
     "firebase-admin": "^13.4.0",
     "joi": "^17.13.3",
@@ -19,7 +20,7 @@
   "devDependencies": {
     "@types/express": "^5.0.3",
     "@types/jest": "^30.0.0",
-    "@types/node": "^24.0.3",
+    "@types/node": "^24.10.0",
     "@types/supertest": "^6.0.3",
     "@types/swagger-jsdoc": "^6.0.4",
     "@types/swagger-ui-express": "^4.1.8",
@@ -40,6 +41,8 @@
     "build": "tsc",
     "test": "jest",
     "lint": "eslint 'src/**/*.{ts,js}' --fix",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "admin:set": "npm run build && node dist/scripts/setAdminClaim.js",
+    "admin:list": "npm run build && node dist/scripts/setAdminClaim.js list"
   }
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -19,6 +19,7 @@ import charityRoutes from './modules/charities/routes/charityRoutes';
 import authRoutes from './modules/auth/routes/authRoutes';
 import paymentRoutes from './modules/payment/routes/paymentRoutes';
 import orderRoutes from './modules/order/routes/orderRoutes';
+import adminRoutes from './modules/order/routes/adminRoutes';
 
 app.use('/api/products', productRoutes);
 app.use('/api/categories', categoryRoutes);
@@ -26,6 +27,7 @@ app.use('/api/charities', charityRoutes);
 app.use('/api/auth', authRoutes);
 app.use('/api/payment', paymentRoutes);
 app.use('/api/order', orderRoutes);
+app.use('/api/admin', adminRoutes);
 
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpecs));
 

--- a/src/modules/order/controllers/exportController.ts
+++ b/src/modules/order/controllers/exportController.ts
@@ -1,0 +1,209 @@
+import { Request, Response } from 'express';
+import { ResponseHandler } from '../../../shared/utils/responseHandler';
+import { OrderRepository } from '../repositories/OrderRepository';
+import { admin } from '../../../shared/config/firebaseConfig';
+import { format } from '@fast-csv/format';
+
+/**
+ * Exports orders as a CSV file within a specified date range.
+ * The CSV is uploaded to Firebase Storage and a signed URL is returned.
+ *
+ * Query parameters:
+ * - start_date: Start date in YYYY-MM-DD format (inclusive)
+ * - end_date: End date in YYYY-MM-DD format (inclusive)
+ *
+ * Returns a signed URL valid for 1 hour to download the CSV file.
+ */
+export const exportOrdersCsv = async (req: Request, res: Response): Promise<void> => {
+  try {
+    // Extract and validate query parameters
+    const { start_date, end_date } = req.query;
+
+    if (!start_date || !end_date) {
+      ResponseHandler.badRequest(
+        res,
+        'Missing required parameters',
+        'Both start_date and end_date are required in YYYY-MM-DD format'
+      );
+      return;
+    }
+
+    // Validate date format and parse dates
+    const startDateStr = start_date as string;
+    const endDateStr = end_date as string;
+
+    const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
+    if (!dateRegex.test(startDateStr) || !dateRegex.test(endDateStr)) {
+      ResponseHandler.badRequest(
+        res,
+        'Invalid date format',
+        'Dates must be in YYYY-MM-DD format'
+      );
+      return;
+    }
+
+    // Parse dates with time boundaries (start at 00:00:00, end at 23:59:59)
+    const startDate = new Date(startDateStr + 'T00:00:00.000Z');
+    const endDate = new Date(endDateStr + 'T23:59:59.999Z');
+
+    if (Number.isNaN(startDate.getTime()) || Number.isNaN(endDate.getTime())) {
+      ResponseHandler.badRequest(res, 'Invalid dates', 'Unable to parse provided dates');
+      return;
+    }
+
+    if (startDate > endDate) {
+      ResponseHandler.badRequest(
+        res,
+        'Invalid date range',
+        'start_date must be before or equal to end_date'
+      );
+      return;
+    }
+
+    // Retrieve orders from repository
+    const orderRepo = new OrderRepository();
+    const orders = await orderRepo.getOrdersByDateRange(startDate, endDate);
+
+    // Check Firebase Storage configuration
+    const bucketName = process.env.FIREBASE_STORAGE_BUCKET;
+    if (!bucketName) {
+      console.error('FIREBASE_STORAGE_BUCKET environment variable is not set');
+      ResponseHandler.internalServerError(
+        res,
+        'Storage not configured',
+        'Firebase Storage bucket is not configured'
+      );
+      return;
+    }
+
+    // Get Firebase Storage bucket
+    const bucket = admin.storage().bucket(bucketName);
+
+    // Generate filename with timestamp
+    const timestamp = new Date().toISOString().split(':').join('-').split('.').join('-');
+    const filename = `exports/orders_${startDateStr}_to_${endDateStr}_${timestamp}.csv`;
+    const file = bucket.file(filename);
+
+    // Create CSV stream
+    const csvStream = format({
+      headers: [
+        'Order ID',
+        'User ID',
+        'Email',
+        'Items Donated',
+        'Donation Amount (£)',
+        'Date of Order/Donation',
+        'Status',
+      ],
+      writeBOM: true, // Add BOM for proper Excel encoding
+    });
+
+    // Create write stream to Firebase Storage
+    const writeStream = file.createWriteStream({
+      metadata: {
+        contentType: 'text/csv',
+        metadata: {
+          exportedBy: (req as any).user?.uid || 'unknown',
+          exportedAt: new Date().toISOString(),
+          dateRange: `${startDateStr} to ${endDateStr}`,
+        },
+      },
+      resumable: false,
+    });
+
+    // Handle stream errors
+    let streamError: Error | null = null;
+    writeStream.on('error', (error) => {
+      console.error('Write stream error:', error);
+      streamError = error;
+    });
+
+    csvStream.on('error', (error) => {
+      console.error('CSV stream error:', error);
+      streamError = error;
+    });
+
+    // Pipe CSV stream to Firebase Storage
+    csvStream.pipe(writeStream);
+
+    // Write data rows
+    if (orders.length === 0) {
+      // No orders found - file will have headers only
+      console.log(`No orders found for date range ${startDateStr} to ${endDateStr}`);
+    } else {
+      for (const order of orders) {
+        // Convert amount from pence to pounds
+        const amountInPounds = (order.amount / 100).toFixed(2);
+
+        // Format date
+        const orderDate = order.createdAt
+          ? new Date(order.createdAt).toISOString()
+          : 'N/A';
+
+        // Get items donated (product name or 'N/A')
+        const items = order.productName || 'N/A';
+
+        // Write row
+        csvStream.write([
+          order.id || 'N/A',
+          order.userId || 'N/A',
+          order.email || 'N/A',
+          items,
+          amountInPounds,
+          orderDate,
+          order.status || 'completed',
+        ]);
+      }
+    }
+
+    // End the CSV stream
+    csvStream.end();
+
+    // Wait for the upload to finish
+    await new Promise<void>((resolve, reject) => {
+      writeStream.on('finish', () => {
+        if (streamError) {
+          reject(streamError);
+        } else {
+          resolve();
+        }
+      });
+
+      writeStream.on('error', (error) => {
+        reject(error);
+      });
+    });
+
+    // Generate signed URL (valid for 1 hour)
+    const [signedUrl] = await file.getSignedUrl({
+      version: 'v4',
+      action: 'read',
+      expires: Date.now() + 60 * 60 * 1000, // 1 hour from now
+    });
+
+    console.log(`CSV export successful: ${filename} (${orders.length} orders)`);
+
+    // Return success response with download URL
+    ResponseHandler.success(
+      res,
+      {
+        url: signedUrl,
+        filename: filename,
+        recordCount: orders.length,
+        dateRange: {
+          start: startDateStr,
+          end: endDateStr,
+        },
+        expiresIn: '1 hour',
+      },
+      'CSV export generated successfully'
+    );
+  } catch (error) {
+    console.error('Error exporting orders to CSV:', error);
+    ResponseHandler.internalServerError(
+      res,
+      'Export failed',
+      error instanceof Error ? error.message : 'Unknown error occurred'
+    );
+  }
+};

--- a/src/modules/order/model/Order.ts
+++ b/src/modules/order/model/Order.ts
@@ -1,6 +1,7 @@
 export interface Order {
   id: string;
   userId: string; // ID of the user who placed the order
+  email?: string; // Email of the user (stored for reporting purposes)
   amount: number; // amount in the smallest currency unit (e.g., pence)
   productId?: string;
   productName?: string;
@@ -15,5 +16,6 @@ export interface Order {
     };
     name?: string;
   };
+  status?: 'completed' | 'pending' | 'failed'; // Order status for tracking
   createdAt: Date;
 }

--- a/src/modules/order/routes/adminRoutes.ts
+++ b/src/modules/order/routes/adminRoutes.ts
@@ -1,0 +1,87 @@
+import { Router } from 'express';
+import { authMiddleware } from '../../../shared/middleware/authMiddleWare';
+import { adminMiddleware } from '../../../shared/middleware/adminMiddleware';
+import { exportOrdersCsv } from '../controllers/exportController';
+
+const router = Router();
+
+/**
+ * @swagger
+ * tags:
+ *   name: Admin
+ *   description: Admin-only operations for export and reporting
+ */
+
+/**
+ * @swagger
+ * /api/admin/export/orders:
+ *   get:
+ *     summary: Export orders as CSV within a date range (Admin only)
+ *     tags: [Admin]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: start_date
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: date
+ *           example: "2024-01-01"
+ *         description: Start date in YYYY-MM-DD format (inclusive)
+ *       - in: query
+ *         name: end_date
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: date
+ *           example: "2024-12-31"
+ *         description: End date in YYYY-MM-DD format (inclusive)
+ *     responses:
+ *       200:
+ *         description: CSV export generated successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: true
+ *                 message:
+ *                   type: string
+ *                   example: "CSV export generated successfully"
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     url:
+ *                       type: string
+ *                       description: Signed URL to download the CSV file (valid for 1 hour)
+ *                     filename:
+ *                       type: string
+ *                       description: Name of the exported file
+ *                     recordCount:
+ *                       type: integer
+ *                       description: Number of orders included in the export
+ *                     dateRange:
+ *                       type: object
+ *                       properties:
+ *                         start:
+ *                           type: string
+ *                         end:
+ *                           type: string
+ *                     expiresIn:
+ *                       type: string
+ *                       example: "1 hour"
+ *       400:
+ *         description: Bad request - Invalid or missing parameters
+ *       401:
+ *         description: Unauthorized - Authentication required
+ *       403:
+ *         description: Forbidden - Admin access required
+ *       500:
+ *         description: Internal server error
+ */
+router.get('/export/orders', authMiddleware, adminMiddleware, exportOrdersCsv);
+
+export default router;

--- a/src/modules/order/tests/exportRoutes.test.ts
+++ b/src/modules/order/tests/exportRoutes.test.ts
@@ -1,0 +1,259 @@
+import request from 'supertest';
+import app from '../../../app';
+import { OrderRepository } from '../repositories/OrderRepository';
+import { admin } from '../../../shared/config/firebaseConfig';
+
+// Mock Firebase Admin
+jest.mock('../../../shared/config/firebaseConfig', () => ({
+  admin: {
+    auth: jest.fn().mockReturnValue({
+      verifyIdToken: jest.fn(),
+    }),
+    storage: jest.fn().mockReturnValue({
+      bucket: jest.fn().mockReturnValue({
+        file: jest.fn().mockReturnValue({
+          createWriteStream: jest.fn(),
+          getSignedUrl: jest.fn(),
+        }),
+      }),
+    }),
+  },
+  firestore: {
+    collection: jest.fn(),
+  },
+}));
+
+jest.mock('../repositories/OrderRepository');
+
+describe('CSV Export Orders - /api/admin/export/orders', () => {
+  let mockToken: string;
+  let mockAdminToken: string;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    
+    // Mock tokens
+    mockToken = 'valid-user-token';
+    mockAdminToken = 'valid-admin-token';
+
+    // Mock auth verification for regular user
+    (admin.auth().verifyIdToken as jest.Mock).mockImplementation((token: string) => {
+      if (token === mockAdminToken) {
+        return Promise.resolve({ uid: 'admin-uid', admin: true });
+      }
+      if (token === mockToken) {
+        return Promise.resolve({ uid: 'user-uid', admin: false });
+      }
+      throw new Error('Invalid token');
+    });
+  });
+
+  describe('Authentication and Authorization', () => {
+    it('should return 401 when no authorization header is provided', async () => {
+      const response = await request(app)
+        .get('/api/admin/export/orders')
+        .query({ start_date: '2024-01-01', end_date: '2024-12-31' });
+
+      expect(response.status).toBe(401);
+      expect(response.body.success).toBe(false);
+    });
+
+    it('should return 403 when user is not an admin', async () => {
+      const response = await request(app)
+        .get('/api/admin/export/orders')
+        .set('Authorization', `Bearer ${mockToken}`)
+        .query({ start_date: '2024-01-01', end_date: '2024-12-31' });
+
+      expect(response.status).toBe(403);
+      expect(response.body.success).toBe(false);
+      expect(response.body.message).toContain('Admin access required');
+    });
+  });
+
+  describe('Input Validation', () => {
+    it('should return 400 when start_date is missing', async () => {
+      const response = await request(app)
+        .get('/api/admin/export/orders')
+        .set('Authorization', `Bearer ${mockAdminToken}`)
+        .query({ end_date: '2024-12-31' });
+
+      expect(response.status).toBe(400);
+      expect(response.body.success).toBe(false);
+      expect(response.body.message).toContain('Missing required parameters');
+    });
+
+    it('should return 400 when end_date is missing', async () => {
+      const response = await request(app)
+        .get('/api/admin/export/orders')
+        .set('Authorization', `Bearer ${mockAdminToken}`)
+        .query({ start_date: '2024-01-01' });
+
+      expect(response.status).toBe(400);
+      expect(response.body.success).toBe(false);
+      expect(response.body.message).toContain('Missing required parameters');
+    });
+
+    it('should return 400 when date format is invalid', async () => {
+      const response = await request(app)
+        .get('/api/admin/export/orders')
+        .set('Authorization', `Bearer ${mockAdminToken}`)
+        .query({ start_date: '2024/01/01', end_date: '2024-12-31' });
+
+      expect(response.status).toBe(400);
+      expect(response.body.success).toBe(false);
+      expect(response.body.message).toContain('Invalid date format');
+    });
+
+    it('should return 400 when start_date is after end_date', async () => {
+      const response = await request(app)
+        .get('/api/admin/export/orders')
+        .set('Authorization', `Bearer ${mockAdminToken}`)
+        .query({ start_date: '2024-12-31', end_date: '2024-01-01' });
+
+      expect(response.status).toBe(400);
+      expect(response.body.success).toBe(false);
+      expect(response.body.message).toContain('Invalid date range');
+    });
+  });
+
+  describe('CSV Export Functionality', () => {
+    beforeEach(() => {
+      // Set up environment variable for storage bucket
+      process.env.FIREBASE_STORAGE_BUCKET = 'test-bucket.appspot.com';
+
+      // Mock storage write stream
+      const mockWriteStream: any = {
+        on: jest.fn((event: string, callback: () => void) => {
+          if (event === 'finish') {
+            setTimeout(callback, 0);
+          }
+          return mockWriteStream;
+        }),
+        write: jest.fn(),
+        end: jest.fn(),
+      };
+
+      const mockFile = {
+        createWriteStream: jest.fn().mockReturnValue(mockWriteStream),
+        getSignedUrl: jest.fn().mockResolvedValue(['https://storage.googleapis.com/signed-url']),
+      };
+
+      const mockBucket = {
+        file: jest.fn().mockReturnValue(mockFile),
+      };
+
+      (admin.storage as jest.Mock).mockReturnValue({
+        bucket: jest.fn().mockReturnValue(mockBucket),
+      });
+    });
+
+    it('should return CSV with headers only when no orders exist', async () => {
+      // Mock empty orders
+      (OrderRepository.prototype.getOrdersByDateRange as jest.Mock).mockResolvedValue([]);
+
+      const response = await request(app)
+        .get('/api/admin/export/orders')
+        .set('Authorization', `Bearer ${mockAdminToken}`)
+        .query({ start_date: '2024-01-01', end_date: '2024-12-31' });
+
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(response.body.data.recordCount).toBe(0);
+      expect(response.body.data.url).toBeDefined();
+    });
+
+    it('should successfully export orders within date range', async () => {
+      // Mock orders data
+      const mockOrders = [
+        {
+          id: 'order-1',
+          userId: 'user-1',
+          email: 'user1@example.com',
+          amount: 5000, // £50.00
+          productName: 'Winter Coat',
+          status: 'completed',
+          createdAt: new Date('2024-06-15'),
+        },
+        {
+          id: 'order-2',
+          userId: 'user-2',
+          email: 'user2@example.com',
+          amount: 2500, // £25.00
+          productName: 'School Supplies',
+          status: 'pending',
+          createdAt: new Date('2024-07-20'),
+        },
+      ];
+
+      (OrderRepository.prototype.getOrdersByDateRange as jest.Mock).mockResolvedValue(mockOrders);
+
+      const response = await request(app)
+        .get('/api/admin/export/orders')
+        .set('Authorization', `Bearer ${mockAdminToken}`)
+        .query({ start_date: '2024-01-01', end_date: '2024-12-31' });
+
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(response.body.data.recordCount).toBe(2);
+      expect(response.body.data.url).toContain('https://');
+      expect(response.body.data.filename).toContain('orders_2024-01-01_to_2024-12-31');
+      expect(response.body.data.expiresIn).toBe('1 hour');
+    });
+
+    it('should handle orders with failed status', async () => {
+      const mockOrders = [
+        {
+          id: 'order-failed',
+          userId: 'user-3',
+          email: 'user3@example.com',
+          amount: 1000,
+          productName: 'Donation',
+          status: 'failed',
+          createdAt: new Date('2024-08-01'),
+        },
+      ];
+
+      (OrderRepository.prototype.getOrdersByDateRange as jest.Mock).mockResolvedValue(mockOrders);
+
+      const response = await request(app)
+        .get('/api/admin/export/orders')
+        .set('Authorization', `Bearer ${mockAdminToken}`)
+        .query({ start_date: '2024-08-01', end_date: '2024-08-31' });
+
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(response.body.data.recordCount).toBe(1);
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should return 500 when storage bucket is not configured', async () => {
+      delete process.env.FIREBASE_STORAGE_BUCKET;
+
+      const response = await request(app)
+        .get('/api/admin/export/orders')
+        .set('Authorization', `Bearer ${mockAdminToken}`)
+        .query({ start_date: '2024-01-01', end_date: '2024-12-31' });
+
+      expect(response.status).toBe(500);
+      expect(response.body.success).toBe(false);
+      expect(response.body.message).toContain('Storage not configured');
+    });
+
+    it('should return 500 when database query fails', async () => {
+      process.env.FIREBASE_STORAGE_BUCKET = 'test-bucket.appspot.com';
+      
+      (OrderRepository.prototype.getOrdersByDateRange as jest.Mock).mockRejectedValue(
+        new Error('Database connection failed')
+      );
+
+      const response = await request(app)
+        .get('/api/admin/export/orders')
+        .set('Authorization', `Bearer ${mockAdminToken}`)
+        .query({ start_date: '2024-01-01', end_date: '2024-12-31' });
+
+      expect(response.status).toBe(500);
+      expect(response.body.success).toBe(false);
+    });
+  });
+});

--- a/src/scripts/setAdminClaim.ts
+++ b/src/scripts/setAdminClaim.ts
@@ -1,0 +1,98 @@
+/**
+ * Admin User Management Script
+ * 
+ * This script helps manage admin privileges for users.
+ * Run this script with Node.js after building the project.
+ * 
+ * Usage:
+ *   npm run build
+ *   node dist/scripts/setAdminClaim.js <firebase-uid> [true|false]
+ * 
+ * Examples:
+ *   node dist/scripts/setAdminClaim.js abc123xyz true   # Grant admin
+ *   node dist/scripts/setAdminClaim.js abc123xyz false  # Revoke admin
+ */
+
+import { admin } from '../shared/config/firebaseConfig';
+
+async function setAdminClaim(uid: string, isAdmin: boolean = true): Promise<void> {
+  try {
+    console.log(`Setting admin claim for user ${uid} to ${isAdmin}...`);
+    
+    // Set custom claims
+    await admin.auth().setCustomUserClaims(uid, { admin: isAdmin });
+    
+    console.log(`✓ Successfully set admin claim for user ${uid}`);
+    console.log(`  Admin status: ${isAdmin}`);
+    console.log('\nNote: The user must refresh their authentication token for changes to take effect.');
+    
+    // Verify the claim was set
+    const user = await admin.auth().getUser(uid);
+    console.log('\nCurrent custom claims:', user.customClaims);
+    
+    process.exit(0);
+  } catch (error) {
+    console.error('✗ Error setting admin claim:', error);
+    if (error instanceof Error) {
+      console.error('  Message:', error.message);
+    }
+    process.exit(1);
+  }
+}
+
+async function listAdminUsers(): Promise<void> {
+  try {
+    console.log('Fetching users with admin privileges...\n');
+    
+    const listUsersResult = await admin.auth().listUsers(1000);
+    const adminUsers = listUsersResult.users.filter(
+      user => user.customClaims && (user.customClaims as any).admin === true
+    );
+    
+    if (adminUsers.length === 0) {
+      console.log('No admin users found.');
+    } else {
+      console.log(`Found ${adminUsers.length} admin user(s):\n`);
+      adminUsers.forEach((user, index) => {
+        console.log(`${index + 1}. UID: ${user.uid}`);
+        console.log(`   Email: ${user.email || 'N/A'}`);
+        console.log(`   Display Name: ${user.displayName || 'N/A'}`);
+        console.log('');
+      });
+    }
+    
+    process.exit(0);
+  } catch (error) {
+    console.error('✗ Error listing admin users:', error);
+    if (error instanceof Error) {
+      console.error('  Message:', error.message);
+    }
+    process.exit(1);
+  }
+}
+
+// Parse command line arguments
+const args = process.argv.slice(2);
+
+if (args.length === 0 || args[0] === 'list') {
+  // List all admin users
+  listAdminUsers();
+} else if (args.length >= 1) {
+  const uid = args[0];
+  const isAdmin = args[1] !== 'false'; // Default to true unless explicitly set to false
+  
+  if (!uid || uid.length < 5) {
+    console.error('Error: Please provide a valid Firebase UID');
+    console.log('\nUsage:');
+    console.log('  Set admin:    npm run admin:set <uid> [true|false]');
+    console.log('  List admins:  npm run admin:list');
+    process.exit(1);
+  }
+  
+  setAdminClaim(uid, isAdmin);
+} else {
+  console.log('Usage:');
+  console.log('  Set admin:    npm run admin:set <uid> [true|false]');
+  console.log('  List admins:  npm run admin:list');
+  process.exit(1);
+}

--- a/src/shared/middleware/adminMiddleware.ts
+++ b/src/shared/middleware/adminMiddleware.ts
@@ -1,0 +1,42 @@
+import { Request, Response, NextFunction } from 'express';
+import { ResponseHandler } from '../utils/responseHandler';
+
+/**
+ * Middleware to check if the authenticated user has admin privileges.
+ * This middleware must be used AFTER authMiddleware.
+ * 
+ * Admin privileges are determined by checking the 'admin' custom claim
+ * on the Firebase user token. To set this claim for a user, use:
+ * 
+ * admin.auth().setCustomUserClaims(uid, { admin: true })
+ * 
+ * @param req - Express request object (expects req.user to be set by authMiddleware)
+ * @param res - Express response object
+ * @param next - Express next function
+ */
+export async function adminMiddleware(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+        const user = (req as any).user;
+
+        if (!user) {
+            ResponseHandler.unauthorized(res, 'Authentication required', 'No user found in request');
+            return;
+        }
+
+        // Check for admin custom claim
+        if (user.admin === true) {
+            next();
+            return;
+        }
+
+        // If no admin claim, deny access
+        ResponseHandler.forbidden(res, 'Admin access required', 'User does not have admin privileges');
+    } catch (error) {
+        console.error('Admin middleware error:', error);
+        ResponseHandler.internalServerError(
+            res,
+            'Authorization check failed',
+            error instanceof Error ? error.message : 'Unknown error'
+        );
+    }
+}


### PR DESCRIPTION
- Add admin-only endpoint: `GET /api/admin/export/orders?start_date=YYYY-MM-DD&end_date=YYYY-MM-DD`.
- Implement `OrderRepository.getOrdersByDateRange(start, end)` to query Firestore and normalize timestamps.
- Generate CSV using `fast-csv`, include headers even when no rows exist.
- Upload CSV to Firebase Storage under `exports/` and return a V4 signed URL (1 hour expiry).
- Add `adminMiddleware` to require Firebase custom claim `admin: true` (provide `setAdminClaim` script).
- Add optional `email` and `status` fields to `Order` interface for reporting; default status handled when missing.
- Add tests covering auth, input validation, empty-range export, failed/pending status, and storage interactions.
- Add documentation: `docs/CSV_EXPORT_FEATURE.md`.

Notes:
- Requires `FIREBASE_STORAGE_BUCKET` env var and service account with Storage write/sign permissions.
- Exports are private; signed URL is returned for download. Consider lifecycle rules to auto-delete old exports.

Closes: #6
