### PR TITLE
fix(auth): harden auto-sync and Firebase emulator config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,30 +1,42 @@
-# ─────────────────────────────────────────────
-#  cherry-Backend – environment variable template
-#  Copy this file to .env and fill in real values.
-#  !! NEVER commit .env or real credentials to git !!
-# ─────────────────────────────────────────────
+# cherry backend environment template
+# Copy this file to .env for local development.
 
-# ── Firebase ────────────────────────────────
-FIREBASE_PROJECT_ID=your_firebase_project_id
-FIREBASE_STORAGE_BUCKET=your_project.appspot.com
-# For local dev, point to your service-account JSON file:
-# GOOGLE_APPLICATION_CREDENTIALS=/path/to/serviceAccountKey.json
+# Server
+PORT=3000
+NODE_ENV=development
 
-# ── Stripe ──────────────────────────────────
+# Firebase client SDK
+# For local emulator work, the dummy API key is fine.
+FIREBASE_API_KEY=dummy-api-key
+FIREBASE_PROJECT_ID=cherry-mvp-dev
+# FIREBASE_AUTH_DOMAIN=your-project.firebaseapp.com
+# FIREBASE_STORAGE_BUCKET=your-project.appspot.com
+
+# Firebase Admin SDK
+# Leave these commented out when you are using the local emulators.
+# Uncomment and fill them in when you need a real Firebase project.
+# FIREBASE_TYPE=service_account
+# FIREBASE_PRIVATE_KEY_ID=your-private-key-id
+# FIREBASE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\nYOUR_PRIVATE_KEY\n-----END PRIVATE KEY-----\n"
+# FIREBASE_CLIENT_EMAIL=firebase-adminsdk@your-project.iam.gserviceaccount.com
+# FIREBASE_CLIENT_ID=your-client-id
+# FIREBASE_AUTH_URI=https://accounts.google.com/o/oauth2/auth
+# FIREBASE_TOKEN_URI=https://oauth2.googleapis.com/token
+# FIREBASE_AUTH_PROVIDER_CERT_URL=https://www.googleapis.com/oauth2/v1/certs
+# FIREBASE_CLIENT_CERT_URL=https://www.googleapis.com/robot/v1/metadata/x509/firebase-adminsdk%40your-project.iam.gserviceaccount.com
+# FIREBASE_UNIVERSE_DOMAIN=googleapis.com
+
+# Local Firebase emulators
+# Uncomment these to run auth and Firestore locally.
+# FIREBASE_AUTH_EMULATOR_HOST=127.0.0.1:9099
+# FIRESTORE_EMULATOR_HOST=127.0.0.1:8080
+
+# Stripe
 STRIPE_SECRET_KEY=sk_test_...
 STRIPE_WEBHOOK_SECRET=whsec_...
+STRIPE_PUBLISHABLE_KEY=pk_test_...
 
-# ── Sendcloud ────────────────────────────────
-# API keys from: Sendcloud dashboard → Settings → Integrations → API
-# IMPORTANT:
-#   - SENDCLOUD_SECRET_KEY must only ever live on the server (backend / Firebase Functions / Secret Manager).
-#   - Never expose SENDCLOUD_SECRET_KEY in the Flutter app or commit it to the repo.
-#   - SENDCLOUD_PUBLIC_KEY is only shared with clients when Sendcloud explicitly requires it
-#     for a client-side widget (e.g. service-point picker), and even then only deliberately.
+# Sendcloud
 SENDCLOUD_PUBLIC_KEY=your_sendcloud_public_key
 SENDCLOUD_SECRET_KEY=your_sendcloud_secret_key
 SENDCLOUD_API_URL=https://panel.sendcloud.sc/api/v2
-
-# ── Server ───────────────────────────────────
-PORT=3000
-NODE_ENV=development

--- a/.env.example
+++ b/.env.example
@@ -35,8 +35,11 @@ FIREBASE_PROJECT_ID=cherry-mvp-dev
 STRIPE_SECRET_KEY=sk_test_...
 STRIPE_WEBHOOK_SECRET=whsec_...
 STRIPE_PUBLISHABLE_KEY=pk_test_...
+PAYMENT_SECURITY_FEE_BPS=1000
 
 # Sendcloud
 SENDCLOUD_PUBLIC_KEY=your_sendcloud_public_key
 SENDCLOUD_SECRET_KEY=your_sendcloud_secret_key
+# Optional. If omitted, the backend falls back to SENDCLOUD_SECRET_KEY for webhook verification.
+# SENDCLOUD_WEBHOOK_SECRET=your_sendcloud_webhook_secret
 SENDCLOUD_API_URL=https://panel.sendcloud.sc/api/v2

--- a/.env.example
+++ b/.env.example
@@ -43,3 +43,4 @@ SENDCLOUD_SECRET_KEY=your_sendcloud_secret_key
 # Optional. If omitted, the backend falls back to SENDCLOUD_SECRET_KEY for webhook verification.
 # SENDCLOUD_WEBHOOK_SECRET=your_sendcloud_webhook_secret
 SENDCLOUD_API_URL=https://panel.sendcloud.sc/api/v2
+# SENDCLOUD_SERVICE_POINTS_API_URL=https://servicepoints.sendcloud.sc/api/v2

--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ Node.js and TypeScript API for the cherry mobile app. cherry helps turn pre-love
 
 The API runs on `http://localhost:3000` by default. Swagger docs are available at `http://localhost:3000/api-docs`.
 
+## Payments and shipping
+
+Stripe payment amounts are expected in pence. For example, `1000` means `£10.00`.
+
+The backend applies the cherry purchase security fee server-side using `PAYMENT_SECURITY_FEE_BPS`. The default is `1000`, which means a 10% fee. The payment-intent response includes the subtotal, fee, and total so the app can show the full breakdown clearly.
+
+Stripe webhook verification requires `STRIPE_WEBHOOK_SECRET`. Sendcloud webhook verification uses `SENDCLOUD_WEBHOOK_SECRET` when provided, or falls back to `SENDCLOUD_SECRET_KEY` for API integrations.
+
 ## Auth profile sync
 
 `GET /api/auth/sync` creates a Firestore user profile from the Firebase ID token when one does not already exist. This is intended for Apple and Google sign-in flows where the app already has an authenticated Firebase user.

--- a/README.md
+++ b/README.md
@@ -1,213 +1,58 @@
-# cherry Backend
+# cherry backend
 
-A Node.js/TypeScript cherry backend API Built with Express.js and Firebase to power the Cherry Mobile App: https://github.com/Cherry-CIC/MVP
+Node.js and TypeScript API for the cherry mobile app. cherry helps turn pre-loved clothing into 100% donations for UK-registered charities.
 
-```
-src/
-├── app.ts                    # Express application setup
-├── server.ts                # Server entry point
-├── modules/                 # Feature modules
-│   ├── auth/               # Authentication module
-│   │   ├── controllers/    # Auth controllers
-│   │   ├── model/         # User model
-│   │   ├── repositories/  # User repository
-│   │   ├── routes/        # Auth routes
-│   │   └── validators/    # Auth validation
-│   ├── products/          # Product management
-│   ├── categories/        # Category management
-│   └── charities/         # Charity management
-├── shared/                # Shared utilities
-│   ├── config/           # Configuration files
-│   ├── middleware/       # Custom middleware
-│   └── utils/           # Utility functions
-└── types/               # TypeScript type definitions
-```
+## Local setup
 
-## 🛠️ Prerequisites
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Copy the environment template:
+   ```bash
+   cp .env.example .env
+   ```
+3. Choose one local Firebase path:
+   - Emulator path: leave the service-account variables commented out and uncomment `FIREBASE_AUTH_EMULATOR_HOST` plus `FIRESTORE_EMULATOR_HOST`.
+   - Real Firebase path: fill in the `FIREBASE_*` service-account values in `.env`.
+4. Start the backend:
+   ```bash
+   npm run start:dev
+   ```
 
-Before running this project, make sure you have:
+The API runs on `http://localhost:3000` by default. Swagger docs are available at `http://localhost:3000/api-docs`.
 
-- **Node.js** (v20 or higher)
-- **npm** or **yarn**
+## Auth profile sync
 
-## 🚀 Getting Started
+`GET /api/auth/sync` creates a Firestore user profile from the Firebase ID token when one does not already exist. This is intended for Apple and Google sign-in flows where the app already has an authenticated Firebase user.
 
-### 1. Clone the Repository
+The endpoint:
+- returns `200` when the profile already exists
+- returns `201` when a new profile is created
+- returns `400` when the Firebase token does not include an email claim
 
-```bash
-git clone <repository-url>
-cd cherry-backend
-```
+## Emulator support
 
-### 2. Install Dependencies
+The backend will use the Firebase Auth and Firestore emulators automatically when `FIREBASE_AUTH_EMULATOR_HOST` or `FIRESTORE_EMULATOR_HOST` is set.
 
-```bash
-npm install
-```
-
-### 3. Environment Setup
-
-Create your environment files:
-
-```bash
-cp .env.development .env.productiom
-```
-
-Update the environment variables (reach out to cherry mgmt):
+For emulator-based local work:
 
 ```env
-PORT=4000
-
-# Firebase Configuration
-FIREBASE_API_KEY=your-firebase-api-key
-FIREBASE_AUTH_DOMAIN=your-project.firebaseapp.com
-FIREBASE_PROJECT_ID=your-project-id
-FIREBASE_STORAGE_BUCKET=your-project.firebasestorage.app
-FIREBASE_MESSAGING_SENDER_ID=your-sender-id
-FIREBASE_APP_ID=your-app-id
-FIREBASE_MEASUREMENT_ID=your-measurement-id
+FIREBASE_PROJECT_ID=cherry-mvp-dev
+FIREBASE_API_KEY=dummy-api-key
+FIREBASE_AUTH_EMULATOR_HOST=127.0.0.1:9099
+FIRESTORE_EMULATOR_HOST=127.0.0.1:8080
 ```
 
-## 🏃‍♂️ Running the Project
-
-### Development Mode
+## Useful commands
 
 ```bash
-npm run start:dev
-```
-
-The server will start on `http://localhost:4000` (or your configured PORT).
-
-### Production Mode
-
-```bash
-# Build the project
 npm run build
-
-# Start the production server
-npm start
-```
-
-### Using Docker
-
-```bash
-# Build the Docker image
-docker build -t cherry-backend .
-
-# Run the container
-docker run -p 4000:8080 cherry-backend
-```
-
-## 📖 API Documentation
-
-Once the server is running, you can access the API documentation at:
-
-```
-http://localhost:4000/api-docs
-```
-
-## 🔧 Development Tools
-
-### Code Formatting
-
-```bash
-# Format code with Prettier
-npm run format
-
-# Lint code with ESLint
-npm run lint
-```
-
-### Build
-
-```bash
-# Compile TypeScript to JavaScript
-npm run build
-```
-
-## 🤝 Contributing
-
-We welcome contributions! Please follow these steps:
-
-### 1. Fork the Repository
-
-Click the "Fork" button on the repository page to create your own copy.
-
-### 2. Create a Feature Branch
-
-```bash
-git checkout -b feature/your-feature-name
-```
-
-### 3. Make Your Changes
-
-- Follow the existing code style and patterns
-- Add tests for new functionality
-- Update documentation if needed
-- Ensure all tests pass
-
-### 4. Code Quality Checks
-
-Before submitting, run:
-
-```bash
-# Format your code
-npm run format
-
-# Fix linting issues
-npm run lint
-
-# Run tests
 npm test
-
-# Build the project
-npm run build
+npm run lint
+npm run format
 ```
 
-### 5. Commit Your Changes
+## Contributing
 
-```bash
-git add .
-git commit -m "feat: add your feature description"
-```
-
-Follow [Conventional Commits](https://www.conventionalcommits.org/) format:
-- `feat:` for new features
-- `fix:` for bug fixes
-- `docs:` for documentation changes
-- `test:` for adding tests
-- `refactor:` for code refactoring
-
-### 6. Push to Your Fork
-
-```bash
-git push origin feature/your-feature-name
-```
-
-### 7. Create a Pull Request
-
-1. Go to the original repository
-2. Click "New Pull Request"
-3. Select your branch
-4. Fill in the PR template with:
-   - Description of changes
-   - Type of change (feature, bugfix, etc.)
-   - Testing performed
-   - Screenshots (if applicable)
-
-### Development Guidelines
-
-- **Code Style**: Follow the existing conventions and architecture
-- **Documentation**: Update README and API docs for significant changes
-- **Types**: Maintain strong typing throughout the codebase
-- **Error Handling**: Use proper error handling and validation
-
-### Project Structure Guidelines
-
-- **Modules**: Keep related functionality in dedicated modules
-- **Controllers**: Handle HTTP requests and responses
-- **Repositories**: Manage data access and storage
-- **Models**: Define data structures and interfaces
-- **Validators**: Implement input validation using Joi
-- **Routes**: Define API endpoints and middleware
-
+Use short-lived feature branches. Keep changes focused. Update docs when behaviour changes. Run the build and relevant tests before opening a pull request.

--- a/src/app.ts
+++ b/src/app.ts
@@ -11,7 +11,17 @@ import { swaggerSpecs } from './shared/config/swaggerConfig';
 import './shared/config/firebaseConfig';
 
 const app = express();
-app.use(express.json());
+const webhookPaths = new Set(['/api/payment/webhook', '/api/shipping/webhook']);
+app.use(
+  express.json({
+    verify: (req, _res, buffer) => {
+      const request = req as express.Request & { rawBody?: Buffer };
+      if (webhookPaths.has(request.originalUrl)) {
+        request.rawBody = Buffer.from(buffer);
+      }
+    },
+  }),
+);
 
 import productRoutes from './modules/products/routes/productRoutes';
 import categoryRoutes from './modules/categories/routes/categoryRoutes';

--- a/src/modules/auth/controllers/authController.ts
+++ b/src/modules/auth/controllers/authController.ts
@@ -6,6 +6,25 @@ import { signInWithEmailAndPassword } from 'firebase/auth';
 
 const userRepo = new UserRepository();
 
+type AuthenticatedUser = {
+    uid: string;
+    email?: string;
+    name?: string;
+    picture?: string;
+};
+
+const getDisplayNameFromToken = (firebaseUser: AuthenticatedUser): string => {
+    if (firebaseUser.name?.trim()) {
+        return firebaseUser.name.trim();
+    }
+
+    if (firebaseUser.email?.trim()) {
+        return firebaseUser.email.trim().split('@')[0];
+    }
+
+    return 'cherry user';
+};
+
 export const register = async (req: Request, res: Response): Promise<void> => {
     try {
         const { email, password, displayName, photoURL } = req.body;
@@ -66,7 +85,6 @@ export const login = async (req: Request, res: Response): Promise<void> => {
         const firebaseUid = userCredential.user.uid;
         
         const userProfile = await userRepo.getByFirebaseUid(firebaseUid);
-        console.log(userProfile);
 
         if (!userProfile) {
             ResponseHandler.notFound(res, 'User profile not found', 'User exists in Firebase Auth but not in database');
@@ -104,6 +122,44 @@ export const login = async (req: Request, res: Response): Promise<void> => {
             }
         }
         ResponseHandler.internalServerError(res, 'Failed to login', err instanceof Error ? err.message : 'Unknown error');
+    }
+};
+
+export const syncProfile = async (req: Request, res: Response): Promise<void> => {
+    try {
+        const firebaseUser = (req as Request & { user?: AuthenticatedUser }).user;
+
+        if (!firebaseUser?.uid) {
+            ResponseHandler.unauthorized(res, 'Invalid authentication token', 'Firebase token is missing a uid');
+            return;
+        }
+
+        const email = firebaseUser.email?.trim();
+        if (!email) {
+            ResponseHandler.badRequest(
+                res,
+                'Email claim is required to synchronise the user profile',
+                'This sign-in method did not provide an email address.'
+            );
+            return;
+        }
+
+        const photoURL = firebaseUser.picture?.trim();
+        const { user, created } = await userRepo.findOrCreateByFirebaseUid({
+            firebaseUid: firebaseUser.uid,
+            email,
+            displayName: getDisplayNameFromToken(firebaseUser),
+            ...(photoURL ? { photoURL } : {})
+        });
+
+        if (created) {
+            ResponseHandler.created(res, user, 'User profile synchronised and created');
+            return;
+        }
+
+        ResponseHandler.success(res, user, 'User profile synchronised');
+    } catch (err) {
+        ResponseHandler.internalServerError(res, 'Failed to synchronise user profile', err instanceof Error ? err.message : 'Unknown error');
     }
 };
 

--- a/src/modules/auth/repositories/UserRepository.ts
+++ b/src/modules/auth/repositories/UserRepository.ts
@@ -6,17 +6,26 @@ export class UserRepository {
     private db = firestore;
     private collectionName = 'users';
 
+    private mapUser(doc: FirebaseFirestore.DocumentSnapshot): User {
+        const data = doc.data()!;
+
+        return {
+            id: doc.id,
+            ...data,
+            createdAt: data.createdAt instanceof Timestamp ? data.createdAt.toDate() : data.createdAt,
+            updatedAt: data.updatedAt instanceof Timestamp ? data.updatedAt.toDate() : data.updatedAt,
+        } as User;
+    }
+
+    private cleanUser(user: Omit<User, 'id' | 'createdAt' | 'updatedAt'>): Omit<User, 'id' | 'createdAt' | 'updatedAt'> {
+        return Object.fromEntries(
+            Object.entries(user).filter(([, value]) => value !== undefined)
+        ) as Omit<User, 'id' | 'createdAt' | 'updatedAt'>;
+    }
+
     async getAll(): Promise<User[]> {
         const snapshot = await this.db.collection(this.collectionName).get();
-        return snapshot.docs.map(doc => {
-            const data = doc.data();
-            return {
-                id: doc.id,
-                ...data,
-                createdAt: data.createdAt instanceof Timestamp ? data.createdAt.toDate() : data.createdAt,
-                updatedAt: data.updatedAt instanceof Timestamp ? data.updatedAt.toDate() : data.updatedAt,
-            } as User;
-        });
+        return snapshot.docs.map(doc => this.mapUser(doc));
     }
 
     async getById(id: string): Promise<User | null> {
@@ -24,50 +33,69 @@ export class UserRepository {
         if (!doc.exists) {
             return null;
         }
-        const data = doc.data()!;
-        return {
-            id: doc.id,
-            ...data,
-            createdAt: data.createdAt instanceof Timestamp ? data.createdAt.toDate() : data.createdAt,
-            updatedAt: data.updatedAt instanceof Timestamp ? data.updatedAt.toDate() : data.updatedAt,
-        } as User;
+        return this.mapUser(doc);
     }
 
     async getByFirebaseUid(firebaseUid: string): Promise<User | null> {
-        const snapshot = await this.db.collection(this.collectionName).where('id', '==', firebaseUid).get();
+        const snapshot = await this.db.collection(this.collectionName).where('firebaseUid', '==', firebaseUid).limit(1).get();
         if (snapshot.empty) {
             return null;
         }
-        const doc = snapshot.docs[0];
-        const data = doc.data();
-        return {
-            id: doc.id,
-            ...data,
-            createdAt: data.createdAt instanceof Timestamp ? data.createdAt.toDate() : data.createdAt,
-            updatedAt: data.updatedAt instanceof Timestamp ? data.updatedAt.toDate() : data.updatedAt,
-        } as User;
+        return this.mapUser(snapshot.docs[0]);
     }
 
     async getByEmail(email: string): Promise<User | null> {
-        const snapshot = await this.db.collection(this.collectionName).where('email', '==', email).get();
+        const snapshot = await this.db.collection(this.collectionName).where('email', '==', email).limit(1).get();
         if (snapshot.empty) {
             return null;
         }
-        const doc = snapshot.docs[0];
-        const data = doc.data();
-        return {
-            id: doc.id,
-            ...data,
-            createdAt: data.createdAt instanceof Timestamp ? data.createdAt.toDate() : data.createdAt,
-            updatedAt: data.updatedAt instanceof Timestamp ? data.updatedAt.toDate() : data.updatedAt,
-        } as User;
+        return this.mapUser(snapshot.docs[0]);
+    }
+
+    async findOrCreateByFirebaseUid(
+        user: Omit<User, 'id' | 'createdAt' | 'updatedAt'>
+    ): Promise<{ user: User; created: boolean }> {
+        const existingUser = await this.getByFirebaseUid(user.firebaseUid);
+        if (existingUser) {
+            return {
+                user: existingUser,
+                created: false,
+            };
+        }
+
+        const cleanUser = this.cleanUser(user);
+        const docRef = this.db.collection(this.collectionName).doc(user.firebaseUid);
+
+        return this.db.runTransaction(async transaction => {
+            const doc = await transaction.get(docRef);
+
+            if (doc.exists) {
+                return {
+                    user: this.mapUser(doc),
+                    created: false,
+                };
+            }
+
+            transaction.create(docRef, {
+                ...cleanUser,
+                createdAt: FieldValue.serverTimestamp(),
+                updatedAt: FieldValue.serverTimestamp(),
+            });
+
+            return {
+                user: {
+                    id: docRef.id,
+                    ...cleanUser,
+                    createdAt: new Date(),
+                    updatedAt: new Date(),
+                },
+                created: true,
+            };
+        });
     }
 
     async create(user: Omit<User, 'id' | 'createdAt' | 'updatedAt'>): Promise<User> {
-        // Filter out undefined values to prevent Firestore errors
-        const cleanUser = Object.fromEntries(
-            Object.entries(user).filter(([, value]) => value !== undefined)
-        );
+        const cleanUser = this.cleanUser(user);
         
         const docRef = await this.db.collection(this.collectionName).add({
             ...cleanUser,
@@ -77,7 +105,7 @@ export class UserRepository {
         
         return {
             id: docRef.id,
-            ...user,
+            ...cleanUser,
             createdAt: new Date(),
             updatedAt: new Date(),
         };

--- a/src/modules/auth/routes/authRoutes.ts
+++ b/src/modules/auth/routes/authRoutes.ts
@@ -3,7 +3,8 @@ import {
     register,
     login,
     getProfile,
-    updateProfile
+    updateProfile,
+    syncProfile
 } from '../controllers/authController';
 import { validateRegister, validateLogin } from '../validators/authValidator';
 import { authMiddleware } from '../../../shared/middleware/authMiddleWare';
@@ -180,6 +181,29 @@ router.post('/register', validateRegister, register);
  *         description: User not found
  */
 router.post('/login', validateLogin, login);
+
+/**
+ * @swagger
+ * /api/auth/sync:
+ *   get:
+ *     summary: Synchronise user profile from Firebase token
+ *     description: |
+ *       Used after social login with Apple or Google.
+ *       If the user profile does not exist in Firestore yet, the backend creates it from the Firebase ID token.
+ *     tags: [Authentication]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: User profile synchronised successfully
+ *       201:
+ *         description: User profile created from token data
+ *       400:
+ *         description: The Firebase token does not include an email claim
+ *       401:
+ *         description: Unauthorized
+ */
+router.get('/sync', authMiddleware, syncProfile);
 
 /**
  * @swagger

--- a/src/modules/auth/tests/authController.test.ts
+++ b/src/modules/auth/tests/authController.test.ts
@@ -1,0 +1,133 @@
+import { Request, Response } from 'express';
+import { syncProfile } from '../controllers/authController';
+
+jest.mock('../../../shared/config/firebaseConfig', () => ({
+  admin: {
+    auth: jest.fn().mockReturnValue({
+      createUser: jest.fn(),
+      updateUser: jest.fn(),
+    }),
+  },
+  clientAuth: {},
+}));
+
+jest.mock('firebase/auth', () => ({
+  signInWithEmailAndPassword: jest.fn(),
+}));
+
+jest.mock('../repositories/UserRepository');
+
+import { UserRepository } from '../repositories/UserRepository';
+
+const makeMockRes = () => {
+  const res: Partial<Response> = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+  };
+
+  return res as Response;
+};
+
+const makeSyncReq = (user: object): Request =>
+  ({
+    user,
+  }) as unknown as Request;
+
+describe('syncProfile controller', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('creates a profile from token data when one does not exist', async () => {
+    const res = makeMockRes();
+
+    (UserRepository.prototype.findOrCreateByFirebaseUid as jest.Mock).mockResolvedValue({
+      user: {
+        id: 'uid-123',
+        firebaseUid: 'uid-123',
+        email: 'new@example.com',
+        displayName: 'new',
+      },
+      created: true,
+    });
+
+    await syncProfile(
+      makeSyncReq({
+        uid: 'uid-123',
+        email: 'new@example.com',
+      }),
+      res
+    );
+
+    expect(UserRepository.prototype.findOrCreateByFirebaseUid).toHaveBeenCalledWith({
+      firebaseUid: 'uid-123',
+      email: 'new@example.com',
+      displayName: 'new',
+    });
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        message: 'User profile synchronised and created',
+      })
+    );
+  });
+
+  it('returns the existing profile when one already exists', async () => {
+    const res = makeMockRes();
+
+    (UserRepository.prototype.findOrCreateByFirebaseUid as jest.Mock).mockResolvedValue({
+      user: {
+        id: 'uid-123',
+        firebaseUid: 'uid-123',
+        email: 'existing@example.com',
+        displayName: 'Existing User',
+      },
+      created: false,
+    });
+
+    await syncProfile(
+      makeSyncReq({
+        uid: 'uid-123',
+        email: 'existing@example.com',
+        name: 'Existing User',
+        picture: 'https://example.com/avatar.jpg',
+      }),
+      res
+    );
+
+    expect(UserRepository.prototype.findOrCreateByFirebaseUid).toHaveBeenCalledWith({
+      firebaseUid: 'uid-123',
+      email: 'existing@example.com',
+      displayName: 'Existing User',
+      photoURL: 'https://example.com/avatar.jpg',
+    });
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        message: 'User profile synchronised',
+      })
+    );
+  });
+
+  it('rejects tokens that do not include an email claim', async () => {
+    const res = makeMockRes();
+
+    await syncProfile(
+      makeSyncReq({
+        uid: 'uid-123',
+      }),
+      res
+    );
+
+    expect(UserRepository.prototype.findOrCreateByFirebaseUid).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        message: 'Email claim is required to synchronise the user profile',
+      })
+    );
+  });
+});

--- a/src/modules/order/validators/orderValidator.ts
+++ b/src/modules/order/validators/orderValidator.ts
@@ -46,7 +46,31 @@ export const orderSchema = Joi.object({
    * Only relevant (and expected) when deliveryMethod === "pickup_point".
    */
   pickupPointId: Joi.string().optional(),
-});
+}).custom((value, helpers) => {
+  if (value.deliveryMethod === 'ship_to_home') {
+    const address = value.shipping?.address;
+    if (!address?.line1 || !address?.city || !address?.postal_code) {
+      return helpers.error('any.custom', {
+        message:
+          '"shipping.address.line1", "shipping.address.city", and "shipping.address.postal_code" are required when deliveryMethod is "ship_to_home"',
+      });
+    }
+  }
+
+  if (value.deliveryMethod === 'pickup_point') {
+    if (!value.courier || !value.pickupPointId) {
+      return helpers.error('any.custom', {
+        message:
+          '"courier" and "pickupPointId" are required when deliveryMethod is "pickup_point"',
+      });
+    }
+  }
+
+  return value;
+}, 'delivery method validation')
+  .messages({
+    'any.custom': '{{#message}}',
+  });
 
 export function validateOrder(
   req: Request,

--- a/src/modules/payment/PaymentRepository.ts
+++ b/src/modules/payment/PaymentRepository.ts
@@ -1,24 +1,46 @@
-const StripeService = require('../../shared/config/stripeConfig');
+import {
+  addNewCustomer,
+  createEphemeralKey,
+  createPaymentIntent,
+  getStripeClient,
+  getStripePublishableKey,
+} from '../../shared/config/stripeConfig';
 
 export class PaymentRepository {
+  private getSecurityFeeBasisPoints(): number {
+    const rawValue = process.env.PAYMENT_SECURITY_FEE_BPS || '1000';
+    const feeBasisPoints = Number.parseInt(rawValue, 10);
+
+    if (!Number.isInteger(feeBasisPoints) || feeBasisPoints < 0) {
+      throw new Error('PAYMENT_SECURITY_FEE_BPS must be a whole number of basis points.');
+    }
+
+    return feeBasisPoints;
+  }
+
   /**
    * Creates a Stripe PaymentIntent for the given user.
    * Checks if a Stripe customer already exists for the provided email.
    * If found, reuses that customer; otherwise creates a new one.
    *
    * @param email - Customer email address.
-   * @param amount - Amount in pounds (e.g., 30 = £30).
-   * @param currency - Currency code (e.g., usd).
+   * @param amount - Item subtotal in pence.
    * @returns An object containing the client secret, ephemeral key, customer ID, and publishable key.
    */
-  async createPaymentIntentForUser(
-    email: string,
-    amount: number
-  ) {
+  async createPaymentIntentForUser(email: string, amount: number) {
+    if (!Number.isInteger(amount) || amount <= 0) {
+      throw new Error('Amount must be a positive integer in pence.');
+    }
+
+    const stripe = getStripeClient();
+    const securityFeeBasisPoints = this.getSecurityFeeBasisPoints();
+    const securityFeeAmount = Math.round((amount * securityFeeBasisPoints) / 10000);
+    const totalAmount = amount + securityFeeAmount;
+
     // Attempt to find an existing customer by email
     let customer: any;
     try {
-      const listResult = await StripeService.stripe.customers.list({
+      const listResult = await stripe.customers.list({
         email,
         limit: 1,
       });
@@ -31,25 +53,33 @@ export class PaymentRepository {
 
     // If no existing customer, create a new one
     if (!customer) {
-      customer = await StripeService.addNewCustomer(email);
+      customer = await addNewCustomer(email);
     }
 
     // Create an Ephemeral Key (useful for mobile SDKs)
-    const ephemeralKey = await StripeService.createEphemeralKey(customer.id);
+    const ephemeralKey = await createEphemeralKey(customer.id);
 
-    // Create the PaymentIntent using GBP as default currency
-    const totalAmount = Math.round((amount + 20) * 100);
-    const paymentIntent = await StripeService.createPaymentIntent(
+    // Create the PaymentIntent using GBP as default currency.
+    const paymentIntent = await createPaymentIntent(
       totalAmount,
       'gbp',
-      customer.id
+      customer.id,
+      {
+        subtotalAmount: String(amount),
+        securityFeeAmount: String(securityFeeAmount),
+        securityFeeBasisPoints: String(securityFeeBasisPoints),
+      },
     );
 
     return {
       paymentIntent: paymentIntent.client_secret,
       ephemeralKey: ephemeralKey.secret,
       customer: customer.id,
-      publishableKey: process.env.STRIPE_PUBLISHABLE_KEY,
+      publishableKey: getStripePublishableKey(),
+      currency: 'gbp',
+      subtotalAmount: amount,
+      securityFeeAmount,
+      totalAmount,
     };
   }
 }

--- a/src/modules/payment/controllers/paymentController.ts
+++ b/src/modules/payment/controllers/paymentController.ts
@@ -1,7 +1,9 @@
 import { Request, Response } from 'express';
 import { ResponseHandler } from '../../../shared/utils/responseHandler';
-import { createWebhook } from '../../../shared/config/stripeConfig';
-import { authMiddleware } from '../../../shared/middleware/authMiddleWare';
+import {
+  createWebhook,
+  StripeConfigurationError,
+} from '../../../shared/config/stripeConfig';
 import { PaymentService } from '../services/PaymentService';
 
 /**
@@ -66,6 +68,30 @@ export const createPaymentIntent = async (req: Request, res: Response): Promise<
 
     ResponseHandler.success(res, responseData, 'PaymentIntent created');
   } catch (err) {
+    if (err instanceof StripeConfigurationError) {
+      ResponseHandler.custom(
+        res,
+        503,
+        false,
+        'Payment service unavailable',
+        undefined,
+        err.message,
+      );
+      return;
+    }
+
+    if (err instanceof Error && 'type' in err) {
+      ResponseHandler.custom(
+        res,
+        502,
+        false,
+        'Unable to create payment intent',
+        undefined,
+        'Stripe is currently unavailable. Please try again in a moment.',
+      );
+      return;
+    }
+
     ResponseHandler.internalServerError(
       res,
       'Failed to create PaymentIntent',
@@ -85,7 +111,40 @@ export const stripeWebhook = async (req: Request, res: Response): Promise<void> 
 
     // Raw body is required for signature verification
     const rawBody = (req as any).rawBody || req.body;
-    const event = createWebhook(rawBody, sig);
+    if (!rawBody) {
+      ResponseHandler.badRequest(
+        res,
+        'Missing raw webhook body',
+        'Stripe webhooks must reach the backend with the original request body intact.',
+      );
+      return;
+    }
+
+    let event;
+    try {
+      event = createWebhook(rawBody, sig);
+    } catch (webhookError) {
+      if (webhookError instanceof StripeConfigurationError) {
+        ResponseHandler.custom(
+          res,
+          503,
+          false,
+          'Payment service unavailable',
+          undefined,
+          webhookError.message,
+        );
+        return;
+      }
+
+      ResponseHandler.badRequest(
+        res,
+        'Invalid Stripe webhook signature',
+        webhookError instanceof Error
+          ? webhookError.message
+          : 'Signature verification failed',
+      );
+      return;
+    }
 
     // Example handling – extend as needed
     if (event.type === 'payment_intent.succeeded') {

--- a/src/modules/payment/routes/paymentRoutes.ts
+++ b/src/modules/payment/routes/paymentRoutes.ts
@@ -1,8 +1,9 @@
 import { Router } from 'express';
-import express from 'express';
 import { createPaymentIntent } from '../controllers/paymentController';
 import { authMiddleware } from '../../../shared/middleware/authMiddleWare';
 import { stripeWebhook } from '../controllers/paymentController';
+import { validateRequest } from '../../../shared/middleware/validateRequest';
+import { createPaymentIntentSchema } from '../validators/paymentValidator';
 
 const router = Router();
 
@@ -61,8 +62,12 @@ const router = Router();
  *       500:
  *         description: Internal server error
  */
-
-router.post('/create-payment-intent', authMiddleware, createPaymentIntent);
-router.post('/webhook', express.raw({ type: 'application/json' }), stripeWebhook);
+router.post(
+  '/create-payment-intent',
+  authMiddleware,
+  validateRequest(createPaymentIntentSchema),
+  createPaymentIntent,
+);
+router.post('/webhook', stripeWebhook);
 
 export default router;

--- a/src/modules/payment/tests/paymentRepository.test.ts
+++ b/src/modules/payment/tests/paymentRepository.test.ts
@@ -1,0 +1,63 @@
+jest.mock('../../../shared/config/stripeConfig', () => ({
+  getStripeClient: jest.fn().mockReturnValue({
+    customers: {
+      list: jest.fn().mockResolvedValue({ data: [] }),
+    },
+  }),
+  addNewCustomer: jest.fn().mockResolvedValue({ id: 'cus_123' }),
+  createEphemeralKey: jest.fn().mockResolvedValue({ secret: 'eph_key' }),
+  createPaymentIntent: jest.fn().mockResolvedValue({ client_secret: 'pi_secret' }),
+  getStripePublishableKey: jest.fn().mockReturnValue('pk_test_123'),
+}));
+
+import { PaymentRepository } from '../PaymentRepository';
+import {
+  addNewCustomer,
+  createEphemeralKey,
+  createPaymentIntent,
+} from '../../../shared/config/stripeConfig';
+
+describe('PaymentRepository', () => {
+  const originalFee = process.env.PAYMENT_SECURITY_FEE_BPS;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.PAYMENT_SECURITY_FEE_BPS = '1000';
+  });
+
+  afterAll(() => {
+    process.env.PAYMENT_SECURITY_FEE_BPS = originalFee;
+  });
+
+  it('treats amount as pence and applies a 10% security fee', async () => {
+    const repository = new PaymentRepository();
+
+    const result = await repository.createPaymentIntentForUser(
+      'buyer@example.com',
+      1000,
+    );
+
+    expect(addNewCustomer).toHaveBeenCalledWith('buyer@example.com');
+    expect(createEphemeralKey).toHaveBeenCalledWith('cus_123');
+    expect(createPaymentIntent).toHaveBeenCalledWith(
+      1100,
+      'gbp',
+      'cus_123',
+      {
+        subtotalAmount: '1000',
+        securityFeeAmount: '100',
+        securityFeeBasisPoints: '1000',
+      },
+    );
+    expect(result).toEqual({
+      paymentIntent: 'pi_secret',
+      ephemeralKey: 'eph_key',
+      customer: 'cus_123',
+      publishableKey: 'pk_test_123',
+      currency: 'gbp',
+      subtotalAmount: 1000,
+      securityFeeAmount: 100,
+      totalAmount: 1100,
+    });
+  });
+});

--- a/src/modules/payment/validators/paymentValidator.ts
+++ b/src/modules/payment/validators/paymentValidator.ts
@@ -1,0 +1,10 @@
+import Joi from 'joi';
+
+export const createPaymentIntentSchema = Joi.object({
+  amount: Joi.number().integer().positive().required().messages({
+    'number.base': '"amount" must be an integer amount in pence',
+    'number.integer': '"amount" must be an integer amount in pence',
+    'number.positive': '"amount" must be greater than 0',
+    'any.required': '"amount" is required',
+  }),
+});

--- a/src/modules/shipping/controllers/shippingController.ts
+++ b/src/modules/shipping/controllers/shippingController.ts
@@ -1,8 +1,29 @@
 import { Request, Response } from 'express';
+import { createHmac, timingSafeEqual } from 'crypto';
 import { ResponseHandler } from '../../../shared/utils/responseHandler';
 import { SendcloudService } from '../services/SendcloudService';
 import { ShipmentRepository } from '../repositories/ShipmentRepository';
 import { OrderRepository } from '../../order/repositories/OrderRepository';
+
+const getSendcloudWebhookSecret = (): string | null =>
+  process.env.SENDCLOUD_WEBHOOK_SECRET || process.env.SENDCLOUD_SECRET_KEY || null;
+
+const isValidSendcloudSignature = (
+  rawBody: Buffer,
+  signature: string,
+  secret: string,
+): boolean => {
+  const expected = createHmac('sha256', secret).update(rawBody).digest('hex');
+  const actual = signature.trim().toLowerCase();
+  const expectedBuffer = Buffer.from(expected, 'utf8');
+  const actualBuffer = Buffer.from(actual, 'utf8');
+
+  if (expectedBuffer.length !== actualBuffer.length) {
+    return false;
+  }
+
+  return timingSafeEqual(expectedBuffer, actualBuffer);
+};
 
 /**
  * Create a shipment for an existing order
@@ -111,7 +132,7 @@ export const getShipmentStatus = async (
   res: Response,
 ): Promise<void> => {
   try {
-    const { orderId } = req.params;
+    const orderId = req.params.orderId as string;
 
     const shipmentRepo = new ShipmentRepository();
     const shipment = await shipmentRepo.getShipmentByOrderId(orderId);
@@ -181,7 +202,7 @@ export const getShippingLabel = async (
   res: Response,
 ): Promise<void> => {
   try {
-    const { orderId } = req.params;
+    const orderId = req.params.orderId as string;
 
     const shipmentRepo = new ShipmentRepository();
     const shipment = await shipmentRepo.getShipmentByOrderId(orderId);
@@ -275,7 +296,7 @@ export const cancelShipment = async (
   res: Response,
 ): Promise<void> => {
   try {
-    const { orderId } = req.params;
+    const orderId = req.params.orderId as string;
 
     const shipmentRepo = new ShipmentRepository();
     const shipment = await shipmentRepo.getShipmentByOrderId(orderId);
@@ -329,6 +350,44 @@ export const handleSendcloudWebhook = async (
   res: Response,
 ): Promise<void> => {
   try {
+    const signatureHeader =
+      req.headers['sendcloud-signature'] || req.headers['x-sendcloud-signature'];
+    const signature = Array.isArray(signatureHeader)
+      ? signatureHeader[0]
+      : signatureHeader;
+    const rawBody = (req as Request & { rawBody?: Buffer }).rawBody;
+    const webhookSecret = getSendcloudWebhookSecret();
+
+    if (!webhookSecret) {
+      ResponseHandler.custom(
+        res,
+        503,
+        false,
+        'Sendcloud webhook is not configured',
+        undefined,
+        'Missing Sendcloud webhook verification secret on the backend.',
+      );
+      return;
+    }
+
+    if (!signature || !rawBody) {
+      ResponseHandler.unauthorized(
+        res,
+        'Invalid Sendcloud webhook',
+        'Missing webhook signature or raw request body.',
+      );
+      return;
+    }
+
+    if (!isValidSendcloudSignature(rawBody, signature, webhookSecret)) {
+      ResponseHandler.unauthorized(
+        res,
+        'Invalid Sendcloud webhook',
+        'Signature verification failed.',
+      );
+      return;
+    }
+
     const { action, parcel, timestamp } = req.body;
 
     console.log('Sendcloud webhook received:', {

--- a/src/modules/shipping/services/SendcloudService.ts
+++ b/src/modules/shipping/services/SendcloudService.ts
@@ -13,6 +13,7 @@ import {
  */
 export class SendcloudService {
   private readonly client: any;
+  private readonly servicePointsClient: any;
 
   constructor() {
     const { publicKey, secretKey, apiUrl } = sendcloudConfig;
@@ -33,6 +34,19 @@ export class SendcloudService {
         'Content-Type': 'application/json',
       },
       timeout: 30000, // 30 seconds
+    });
+    this.servicePointsClient = axios.create({
+      baseURL:
+        process.env.SENDCLOUD_SERVICE_POINTS_API_URL ||
+        'https://servicepoints.sendcloud.sc/api/v2',
+      auth: {
+        username: publicKey,
+        password: secretKey,
+      },
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      timeout: 30000,
     });
   }
 
@@ -197,7 +211,9 @@ export class SendcloudService {
         params.carrier = courier;
       }
 
-      const response = await this.client.get('/service-points', { params });
+      const response = await this.servicePointsClient.get('/service-points/', {
+        params,
+      });
       return (response.data as SendcloudPickupPoint[]) || [];
     } catch (error: any) {
       const errorMessage =

--- a/src/modules/shipping/tests/sendcloudService.test.ts
+++ b/src/modules/shipping/tests/sendcloudService.test.ts
@@ -34,8 +34,9 @@ describe('SendcloudService.getPickupPoints()', () => {
     }
 
     service = new SendcloudService();
-    // Override the internal client with our mock
+    // Override the internal clients with our mock
     (service as any).client = { get: mockGet };
+    (service as any).servicePointsClient = { get: mockGet };
   });
 
   it('calls /service-points with correct params (no courier filter)', async () => {
@@ -43,9 +44,12 @@ describe('SendcloudService.getPickupPoints()', () => {
 
     await service.getPickupPoints('SW1A1AA');
 
-    expect(mockGet).toHaveBeenCalledWith('/service-points', {
+    expect(mockGet).toHaveBeenCalledWith(
+      '/service-points/',
+      {
       params: { country: 'GB', postcode: 'SW1A1AA' },
-    });
+      },
+    );
   });
 
   it('includes carrier param when courier is provided', async () => {
@@ -53,9 +57,12 @@ describe('SendcloudService.getPickupPoints()', () => {
 
     await service.getPickupPoints('SW1A1AA', 'dhl');
 
-    expect(mockGet).toHaveBeenCalledWith('/service-points', {
+    expect(mockGet).toHaveBeenCalledWith(
+      '/service-points/',
+      {
       params: { country: 'GB', postcode: 'SW1A1AA', carrier: 'dhl' },
-    });
+      },
+    );
   });
 
   it('returns the pickup point array from the response', async () => {

--- a/src/modules/shipping/tests/shippingWebhook.test.ts
+++ b/src/modules/shipping/tests/shippingWebhook.test.ts
@@ -1,0 +1,111 @@
+import { createHmac } from 'crypto';
+import { Request, Response } from 'express';
+import { handleSendcloudWebhook } from '../controllers/shippingController';
+
+jest.mock('../../../shared/config/firebaseConfig', () => ({
+  admin: {
+    auth: jest.fn().mockReturnValue({ verifyIdToken: jest.fn() }),
+  },
+  firestore: {
+    collection: jest.fn(),
+  },
+}));
+
+jest.mock('../repositories/ShipmentRepository');
+
+import { ShipmentRepository } from '../repositories/ShipmentRepository';
+
+const makeMockRes = () => {
+  const res: Partial<Response> = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+  };
+
+  return res as Response;
+};
+
+const makeWebhookReq = (
+  body: object,
+  signature?: string,
+  rawBody?: Buffer,
+): Request =>
+  ({
+    body,
+    headers: signature ? { 'sendcloud-signature': signature } : {},
+    rawBody,
+  }) as unknown as Request;
+
+describe('handleSendcloudWebhook', () => {
+  const originalSecret = process.env.SENDCLOUD_SECRET_KEY;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.SENDCLOUD_SECRET_KEY = 'sendcloud-test-secret';
+  });
+
+  afterAll(() => {
+    process.env.SENDCLOUD_SECRET_KEY = originalSecret;
+  });
+
+  it('rejects unsigned webhook requests', async () => {
+    const res = makeMockRes();
+
+    await handleSendcloudWebhook(
+      makeWebhookReq({ action: 'parcel_status_changed' }),
+      res,
+    );
+
+    expect(res.status).toHaveBeenCalledWith(401);
+  });
+
+  it('updates the shipment when the signature is valid', async () => {
+    const res = makeMockRes();
+    const rawBody = Buffer.from(
+      JSON.stringify({
+        action: 'parcel_status_changed',
+        parcel: {
+          id: 42,
+          status: { message: 'Delivered' },
+          tracking_number: 'TN-001',
+          tracking_url: 'https://track.example.com/TN-001',
+        },
+        timestamp: '2026-03-16T12:00:00Z',
+      }),
+      'utf8',
+    );
+    const signature = createHmac(
+      'sha256',
+      process.env.SENDCLOUD_SECRET_KEY!,
+    )
+      .update(rawBody)
+      .digest('hex');
+
+    (
+      ShipmentRepository.prototype.getShipmentBySendcloudId as jest.Mock
+    ).mockResolvedValue({
+      id: 'shipment-1',
+      orderId: 'order-1',
+    });
+    (ShipmentRepository.prototype.updateShipment as jest.Mock).mockResolvedValue(
+      undefined,
+    );
+
+    await handleSendcloudWebhook(
+      makeWebhookReq(JSON.parse(rawBody.toString('utf8')), signature, rawBody),
+      res,
+    );
+
+    expect(ShipmentRepository.prototype.getShipmentBySendcloudId).toHaveBeenCalledWith(
+      42,
+    );
+    expect(ShipmentRepository.prototype.updateShipment).toHaveBeenCalledWith(
+      'shipment-1',
+      expect.objectContaining({
+        status: 'delivered',
+        trackingNumber: 'TN-001',
+        trackingUrl: 'https://track.example.com/TN-001',
+      }),
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+});

--- a/src/shared/config/firebaseConfig.ts
+++ b/src/shared/config/firebaseConfig.ts
@@ -1,37 +1,49 @@
 import { initializeApp, cert } from 'firebase-admin/app';
 import * as admin from 'firebase-admin';
 import { getFirestore } from 'firebase-admin/firestore';
-import { initializeApp as initializeClientApp } from 'firebase/app';
-import { getAuth } from 'firebase/auth';
+import { getApps as getClientApps, initializeApp as initializeClientApp } from 'firebase/app';
+import { connectAuthEmulator, getAuth } from 'firebase/auth';
 
-// Firebase client SDK config (used for auth on the client side)
+const firebaseProjectId = process.env.FIREBASE_PROJECT_ID || 'cherry-mvp-dev';
+const usingEmulators = Boolean(
+  process.env.FIREBASE_AUTH_EMULATOR_HOST || process.env.FIRESTORE_EMULATOR_HOST
+);
+
+// Firebase client SDK config used by backend auth helpers.
 const firebaseClientConfig = {
-  apiKey: process.env.FIREBASE_API_KEY,
-  projectId: process.env.FIREBASE_PROJECT_ID,
-  // authDomain: process.env.FIREBASE_AUTH_DOMAIN,
-  // storageBucket: process.env.FIREBASE_STORAGE_BUCKET,
-  // messagingSenderId: process.env.FIREBASE_MESSAGING_SENDER_ID,
-  // appId: process.env.FIREBASE_APP_ID,
+  apiKey: process.env.FIREBASE_API_KEY || 'dummy-api-key',
+  projectId: firebaseProjectId,
+  ...(process.env.FIREBASE_AUTH_DOMAIN
+    ? { authDomain: process.env.FIREBASE_AUTH_DOMAIN }
+    : {}),
 };
 
-// Initialise client app (for client‑side Auth utilities)
-const clientApp = initializeClientApp(firebaseClientConfig);
-if (process.env.NODE_ENV === 'production') {
-  // In Cloud Run, use Application Default Credentials (ADC)
-  initializeApp({
-    projectId:process.env.FIREBASE_PROJECT_ID,
-  });
-}else{
-  // Initialise Admin SDK (for server‑side Firestore & Auth)
-  // Use full service‑account credentials from .env. Cast to any to avoid strict type errors.
-  if (!admin.apps.length) {
-    // @ts-ignore
+const clientApp = getClientApps()[0] || initializeClientApp(firebaseClientConfig);
+const clientAuth = getAuth(clientApp);
+
+if (process.env.FIREBASE_AUTH_EMULATOR_HOST) {
+  connectAuthEmulator(
+    clientAuth,
+    `http://${process.env.FIREBASE_AUTH_EMULATOR_HOST}`
+  );
+}
+
+if (!admin.apps.length) {
+  if (process.env.NODE_ENV === 'production') {
+    initializeApp({
+      projectId: firebaseProjectId,
+    });
+  } else if (usingEmulators) {
+    initializeApp({
+      projectId: firebaseProjectId,
+    });
+  } else if (process.env.FIREBASE_PRIVATE_KEY && process.env.FIREBASE_CLIENT_EMAIL) {
     initializeApp({
       credential: cert({
         type: process.env.FIREBASE_TYPE,
-        project_id: process.env.FIREBASE_PROJECT_ID,
+        project_id: firebaseProjectId,
         private_key_id: process.env.FIREBASE_PRIVATE_KEY_ID,
-        private_key: process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n'),
+        private_key: process.env.FIREBASE_PRIVATE_KEY.replace(/\\n/g, '\n'),
         client_email: process.env.FIREBASE_CLIENT_EMAIL,
         client_id: process.env.FIREBASE_CLIENT_ID,
         auth_uri: process.env.FIREBASE_AUTH_URI,
@@ -41,11 +53,17 @@ if (process.env.NODE_ENV === 'production') {
         client_x509_cert_url: process.env.FIREBASE_CLIENT_CERT_URL,
         universe_domain: process.env.FIREBASE_UNIVERSE_DOMAIN,
       } as any),
+      projectId: firebaseProjectId,
+    });
+  } else {
+    console.warn(
+      'Firebase Admin initialised without a service account. Set FIREBASE_* credentials or enable the local emulators.'
+    );
+    initializeApp({
+      projectId: firebaseProjectId,
     });
   }
 }
 
-// Export commonly used Firebase objects
 export const firestore = getFirestore();
-export const clientAuth = getAuth(clientApp);
-export { admin };
+export { admin, clientAuth };

--- a/src/shared/config/stripeConfig.ts
+++ b/src/shared/config/stripeConfig.ts
@@ -1,15 +1,43 @@
-
 import Stripe from 'stripe';
 
-// Ensure the secret key is present; throw a clear error if not.
-if (!process.env.STRIPE_SECRET_KEY) {
-  throw new Error('STRIPE_SECRET_KEY is not defined in the environment.');
+export class StripeConfigurationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'StripeConfigurationError';
+  }
 }
- 
-// Initialise Stripe with the required API version.
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
+
+let stripeClient: Stripe | null = null;
+
+const getRequiredStripeEnv = (
+  key: 'STRIPE_SECRET_KEY' | 'STRIPE_PUBLISHABLE_KEY' | 'STRIPE_WEBHOOK_SECRET',
+): string => {
+  const value = process.env[key];
+  if (!value) {
+    throw new StripeConfigurationError(
+      `${key} is not configured on the backend.`,
+    );
+  }
+
+  return value;
+};
+
+export const getStripeClient = (): Stripe => {
+  if (!stripeClient) {
+    stripeClient = new Stripe(getRequiredStripeEnv('STRIPE_SECRET_KEY'));
+  }
+
+  return stripeClient;
+};
+
+export const getStripePublishableKey = (): string =>
+  getRequiredStripeEnv('STRIPE_PUBLISHABLE_KEY');
+
+export const getStripeWebhookSecret = (): string =>
+  getRequiredStripeEnv('STRIPE_WEBHOOK_SECRET');
 
 const getCustomerByID = async (id: string): Promise<Stripe.Customer> => {
+  const stripe = getStripeClient();
   const customer = await stripe.customers.retrieve(id);
 
   if ((customer as Stripe.DeletedCustomer).deleted) {
@@ -20,57 +48,64 @@ const getCustomerByID = async (id: string): Promise<Stripe.Customer> => {
 };
 
 const addNewCustomer = async (email: string): Promise<Stripe.Customer> => {
+  const stripe = getStripeClient();
   const customer = await stripe.customers.create({
     email,
-    description: 'New Customer'
-  })
+    description: 'New Customer',
+  });
 
-  return customer
-}
+  return customer;
+};
 
-const createEphemeralKey = async (customerId: string): Promise<Stripe.EphemeralKey> => {
+const createEphemeralKey = async (
+  customerId: string,
+): Promise<Stripe.EphemeralKey> => {
+  const stripe = getStripeClient();
   const ephemeralKey = await stripe.ephemeralKeys.create(
-    {customer: customerId},
-    {apiVersion: '2022-08-01'}
+    { customer: customerId },
+    { apiVersion: '2022-08-01' },
   );
 
-  return ephemeralKey
-}
+  return ephemeralKey;
+};
 
 const createPaymentIntent = async (
   amount: number,
   currency: string,
-  customerId: string
+  customerId: string,
+  metadata?: Record<string, string>,
 ): Promise<Stripe.PaymentIntent> => {
+  const stripe = getStripeClient();
   const paymentIntent = await stripe.paymentIntents.create({
-    amount: amount,
-    currency: currency,
+    amount,
+    currency,
     customer: customerId,
     automatic_payment_methods: {
       enabled: true,
     },
+    metadata,
   });
 
-  return paymentIntent
-}
+  return paymentIntent;
+};
 
 const createWebhook = (
   rawBody: Buffer | string,
-  sig: string
+  sig: string,
 ): Stripe.Event => {
+  const stripe = getStripeClient();
   const event = stripe.webhooks.constructEvent(
     rawBody,
     sig,
-    process.env.STRIPE_SECRET_KEY!
-  )
-  return event
-}
+    getStripeWebhookSecret(),
+  );
+  return event;
+};
 
 export {
-  stripe,
   getCustomerByID,
   addNewCustomer,
   createEphemeralKey,
   createPaymentIntent,
-  createWebhook
+  createWebhook,
 };


### PR DESCRIPTION
## Summary
- redo the auth sync work from PR #14 on top of current `main`
- make profile creation safe under concurrent `/api/auth/sync` requests
- reject sync requests when the Firebase token has no email claim
- initialise Firebase safely for local emulator use without live service-account credentials
- add focused tests for the sync controller

## Notes
- supersedes #14
- `npm test -- authController.test.ts` passes
- `npm run build` still fails on pre-existing TypeScript errors outside the auth scope