### PR TITLE
Fix PaymentIntent amount handling

### DIFF
--- a/src/modules/payment/PaymentRepository.ts
+++ b/src/modules/payment/PaymentRepository.ts
@@ -1,3 +1,8 @@
+import {
+  parsePositivePenceAmount,
+  PAYMENT_CURRENCY,
+} from './utils/paymentAmount';
+
 const StripeService = require('../../shared/config/stripeConfig');
 
 export class PaymentRepository {
@@ -7,14 +12,16 @@ export class PaymentRepository {
    * If found, reuses that customer; otherwise creates a new one.
    *
    * @param email - Customer email address.
-   * @param amount - Amount in pounds (e.g., 30 = £30).
-   * @param currency - Currency code (e.g., usd).
-   * @returns An object containing the client secret, ephemeral key, customer ID, and publishable key.
+   * @param amount - Amount in the smallest currency unit, pence for GBP.
+   * @returns An object containing the client secret, amount, currency, ephemeral key, customer ID, and publishable key.
    */
   async createPaymentIntentForUser(
     email: string,
-    amount: number
+    amount: unknown
   ) {
+    const totalAmountPence = parsePositivePenceAmount(amount);
+    const currency = PAYMENT_CURRENCY;
+
     // Attempt to find an existing customer by email
     let customer: any;
     try {
@@ -37,20 +44,23 @@ export class PaymentRepository {
     // Create an Ephemeral Key (useful for mobile SDKs)
     const ephemeralKey = await StripeService.createEphemeralKey(customer.id);
 
-    // Create the PaymentIntent using GBP as default currency
-    const totalAmount = Math.round((amount + 20) * 100);
+    // Create the PaymentIntent using GBP as default currency. The app sends
+    // minor units, so do not add fees or convert pounds again here.
     const paymentIntent = await StripeService.createPaymentIntent(
-      totalAmount,
-      'gbp',
+      totalAmountPence,
+      currency,
       customer.id
     );
 
     return {
       paymentIntentId: paymentIntent.id,
+      paymentIntent: paymentIntent.client_secret,
       clientSecret: paymentIntent.client_secret,
       ephemeralKey: ephemeralKey.secret,
       customer: customer.id,
       publishableKey: process.env.STRIPE_PUBLISHABLE_KEY,
+      amount: totalAmountPence,
+      currency,
     };
   }
 }

--- a/src/modules/payment/controllers/paymentController.ts
+++ b/src/modules/payment/controllers/paymentController.ts
@@ -3,6 +3,10 @@ import { ResponseHandler } from '../../../shared/utils/responseHandler';
 import { createWebhook } from '../../../shared/config/stripeConfig';
 import { authMiddleware } from '../../../shared/middleware/authMiddleWare';
 import { PaymentService } from '../services/PaymentService';
+import {
+  INVALID_PAYMENT_AMOUNT_MESSAGE,
+  parsePositivePenceAmount,
+} from '../utils/paymentAmount';
 
 /**
  * @swagger
@@ -41,14 +45,24 @@ import { PaymentService } from '../services/PaymentService';
  *                   properties:
  *                     paymentIntentId:
  *                       type: string
+ *                     paymentIntent:
+ *                       type: string
+ *                       description: Backwards-compatible alias for clientSecret
  *                     clientSecret:
  *                       type: string
+ *                       description: Stripe PaymentIntent client secret used by the Flutter Stripe SDK
  *                     ephemeralKey:
  *                       type: string
  *                     customer:
  *                       type: string
  *                     publishableKey:
  *                       type: string
+ *                     amount:
+ *                       type: integer
+ *                       description: PaymentIntent amount in pence
+ *                     currency:
+ *                       type: string
+ *                       example: gbp
  *       400:
  *         description: Bad request
  *       500:
@@ -61,13 +75,25 @@ export const createPaymentIntent = async (req: Request, res: Response): Promise<
   
     // Extract amount (currency is fixed to GBP)
     const { amount } = req.body;
+    const totalAmountPence = parsePositivePenceAmount(amount);
   
     // Use service to handle Stripe logic and reuse existing customers when possible
     const paymentService = new PaymentService();
-    const responseData = await paymentService.createPaymentIntentForUserByUid(firebaseUid, amount);
+    const responseData = await paymentService.createPaymentIntentForUserByUid(
+      firebaseUid,
+      totalAmountPence
+    );
 
     ResponseHandler.success(res, responseData, 'PaymentIntent created');
   } catch (err) {
+    if (
+      err instanceof Error &&
+      err.message === INVALID_PAYMENT_AMOUNT_MESSAGE
+    ) {
+      ResponseHandler.badRequest(res, 'Invalid amount', err.message);
+      return;
+    }
+
     ResponseHandler.internalServerError(
       res,
       'Failed to create PaymentIntent',

--- a/src/modules/payment/routes/paymentRoutes.ts
+++ b/src/modules/payment/routes/paymentRoutes.ts
@@ -50,14 +50,24 @@ const router = Router();
  *                   properties:
  *                     paymentIntentId:
  *                       type: string
+ *                     paymentIntent:
+ *                       type: string
+ *                       description: Backwards-compatible alias for clientSecret
  *                     clientSecret:
  *                       type: string
+ *                       description: Stripe PaymentIntent client secret used by the Flutter Stripe SDK
  *                     ephemeralKey:
  *                       type: string
  *                     customer:
  *                       type: string
  *                     publishableKey:
  *                       type: string
+ *                     amount:
+ *                       type: integer
+ *                       description: PaymentIntent amount in pence
+ *                     currency:
+ *                       type: string
+ *                       example: gbp
  *       400:
  *         description: Bad request
  *       500:

--- a/src/modules/payment/services/PaymentService.ts
+++ b/src/modules/payment/services/PaymentService.ts
@@ -14,8 +14,8 @@ export class PaymentService {
   /**
    * Creates a Stripe PaymentIntent for a user identified by Firebase UID.
    * @param firebaseUid - Firebase UID of the authenticated user.
-   * @param amount - Amount in the smallest currency unit (e.g., cents).
-   * @returns An object containing the client secret, ephemeral key, customer ID, and publishable key.
+   * @param amount - Amount in the smallest currency unit, pence for GBP.
+   * @returns An object containing the client secret, amount, currency, ephemeral key, customer ID, and publishable key.
    */
   async createPaymentIntentForUserByUid(
     firebaseUid: string,

--- a/src/modules/payment/tests/paymentRepository.test.ts
+++ b/src/modules/payment/tests/paymentRepository.test.ts
@@ -1,0 +1,67 @@
+const mockCustomersList = jest.fn();
+const mockAddNewCustomer = jest.fn();
+const mockCreateEphemeralKey = jest.fn();
+const mockCreatePaymentIntent = jest.fn();
+
+jest.mock('../../../shared/config/stripeConfig', () => ({
+  stripe: {
+    customers: {
+      list: mockCustomersList,
+    },
+  },
+  addNewCustomer: mockAddNewCustomer,
+  createEphemeralKey: mockCreateEphemeralKey,
+  createPaymentIntent: mockCreatePaymentIntent,
+}));
+
+import { PaymentRepository } from '../PaymentRepository';
+
+describe('PaymentRepository', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.STRIPE_PUBLISHABLE_KEY = 'pk_test_123';
+    mockCustomersList.mockResolvedValue({
+      data: [{ id: 'cus_existing' }],
+    });
+    mockCreateEphemeralKey.mockResolvedValue({
+      secret: 'ek_test_123',
+    });
+    mockCreatePaymentIntent.mockResolvedValue({
+      id: 'pi_123',
+      client_secret: 'pi_123_secret_456',
+    });
+  });
+
+  it('creates payment intents using the supplied minor-unit amount without converting pounds again', async () => {
+    const result = await new PaymentRepository().createPaymentIntentForUser(
+      'buyer@example.com',
+      2599,
+    );
+
+    expect(mockCreatePaymentIntent).toHaveBeenCalledWith(
+      2599,
+      'gbp',
+      'cus_existing',
+    );
+    expect(result).toEqual({
+      paymentIntentId: 'pi_123',
+      paymentIntent: 'pi_123_secret_456',
+      clientSecret: 'pi_123_secret_456',
+      ephemeralKey: 'ek_test_123',
+      customer: 'cus_existing',
+      publishableKey: 'pk_test_123',
+      amount: 2599,
+      currency: 'gbp',
+    });
+  });
+
+  it('rejects invalid payment amounts before calling Stripe', async () => {
+    await expect(
+      new PaymentRepository().createPaymentIntentForUser('buyer@example.com', 0),
+    ).rejects.toThrow(
+      'Amount must be a positive integer in the smallest currency unit',
+    );
+
+    expect(mockCreatePaymentIntent).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/payment/tests/paymentRoutes.test.ts
+++ b/src/modules/payment/tests/paymentRoutes.test.ts
@@ -1,0 +1,166 @@
+const mockGetUserById = jest.fn();
+const mockCustomersList = jest.fn();
+const mockCustomersCreate = jest.fn();
+const mockEphemeralKeysCreate = jest.fn();
+const mockPaymentIntentsCreate = jest.fn();
+
+const mockStripeClient = {
+  customers: {
+    list: mockCustomersList,
+    create: mockCustomersCreate,
+  },
+  ephemeralKeys: {
+    create: mockEphemeralKeysCreate,
+  },
+  paymentIntents: {
+    create: mockPaymentIntentsCreate,
+  },
+  webhooks: {
+    constructEvent: jest.fn(),
+  },
+};
+
+jest.mock('stripe', () => jest.fn().mockImplementation(() => mockStripeClient));
+
+jest.mock('../../../shared/middleware/authMiddleWare', () => ({
+  authMiddleware: (req: any, _res: any, next: any) => {
+    req.user = { uid: 'firebase-user-1' };
+    next();
+  },
+}));
+
+jest.mock('../../auth/repositories/UserRepository', () => ({
+  UserRepository: jest.fn().mockImplementation(() => ({
+    getById: mockGetUserById,
+  })),
+}));
+
+process.env.STRIPE_SECRET_KEY = 'sk_test_secret';
+process.env.STRIPE_PUBLISHABLE_KEY = 'pk_test_123';
+
+import express from 'express';
+import request from 'supertest';
+
+const paymentRoutes = require('../routes/paymentRoutes').default;
+
+const app = express();
+app.use(express.json());
+app.use('/api/payment', paymentRoutes);
+
+describe('paymentRoutes.createPaymentIntent', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.STRIPE_PUBLISHABLE_KEY = 'pk_test_123';
+
+    mockGetUserById.mockResolvedValue({
+      id: 'firebase-user-1',
+      email: 'buyer@example.com',
+    });
+    mockCustomersList.mockResolvedValue({
+      data: [{ id: 'cus_existing' }],
+    });
+    mockCustomersCreate.mockResolvedValue({
+      id: 'cus_new',
+    });
+    mockEphemeralKeysCreate.mockResolvedValue({
+      secret: 'ek_test_123',
+    });
+    mockPaymentIntentsCreate.mockImplementation(async (payload) => ({
+      id: 'pi_test_123',
+      client_secret: 'pi_test_123_secret_456',
+      amount: payload.amount,
+      currency: payload.currency,
+    }));
+  });
+
+  it.each([100, 338, 448, 1099])(
+    'sends %i pence directly to Stripe',
+    async (amount) => {
+      const response = await request(app)
+        .post('/api/payment/create-payment-intent')
+        .send({ amount });
+
+      expect(response.status).toBe(200);
+      expect(mockPaymentIntentsCreate).toHaveBeenCalledWith({
+        amount,
+        currency: 'gbp',
+        customer: 'cus_existing',
+        automatic_payment_methods: {
+          enabled: true,
+        },
+      });
+      expect(typeof mockPaymentIntentsCreate.mock.calls[0][0].amount).toBe(
+        'number',
+      );
+    },
+  );
+
+  it('does not inflate 448 pence by multiplying it or adding a fee before multiplying', async () => {
+    await request(app)
+      .post('/api/payment/create-payment-intent')
+      .send({ amount: 448 });
+
+    const stripeAmount = mockPaymentIntentsCreate.mock.calls[0][0].amount;
+
+    expect(stripeAmount).toBe(448);
+    expect(stripeAmount).not.toBe(44800);
+    expect(stripeAmount).not.toBe(46800);
+  });
+
+  it('normalises an integer pence string to a number before calling Stripe', async () => {
+    await request(app)
+      .post('/api/payment/create-payment-intent')
+      .send({ amount: '448' });
+
+    expect(mockPaymentIntentsCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        amount: 448,
+        currency: 'gbp',
+      }),
+    );
+    expect(typeof mockPaymentIntentsCreate.mock.calls[0][0].amount).toBe(
+      'number',
+    );
+  });
+
+  it.each([
+    ['missing amount', {}],
+    ['zero amount', { amount: 0 }],
+    ['negative amount', { amount: -1 }],
+    ['decimal amount', { amount: 448.5 }],
+    ['non-numeric string amount', { amount: 'not-a-number' }],
+  ])('rejects %s', async (_caseName, body) => {
+    const response = await request(app)
+      .post('/api/payment/create-payment-intent')
+      .send(body);
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        success: false,
+        message: 'Invalid amount',
+        error: 'Amount must be a positive integer in the smallest currency unit',
+      }),
+    );
+    expect(mockPaymentIntentsCreate).not.toHaveBeenCalled();
+    expect(mockCustomersList).not.toHaveBeenCalled();
+    expect(mockEphemeralKeysCreate).not.toHaveBeenCalled();
+  });
+
+  it('returns the client secret and PaymentIntent metadata expected by Flutter', async () => {
+    const response = await request(app)
+      .post('/api/payment/create-payment-intent')
+      .send({ amount: 448 });
+
+    expect(response.status).toBe(200);
+    expect(response.body.data).toEqual(
+      expect.objectContaining({
+        clientSecret: 'pi_test_123_secret_456',
+        paymentIntent: 'pi_test_123_secret_456',
+        paymentIntentId: 'pi_test_123',
+        amount: 448,
+        currency: 'gbp',
+      }),
+    );
+  });
+});

--- a/src/modules/payment/utils/paymentAmount.ts
+++ b/src/modules/payment/utils/paymentAmount.ts
@@ -1,0 +1,32 @@
+export const PAYMENT_CURRENCY = 'gbp';
+
+export const INVALID_PAYMENT_AMOUNT_MESSAGE =
+  'Amount must be a positive integer in the smallest currency unit';
+
+const integerPencePattern = /^\d+$/;
+
+const assertPositiveIntegerPence = (amount: number): number => {
+  if (!Number.isSafeInteger(amount) || amount <= 0) {
+    throw new Error(INVALID_PAYMENT_AMOUNT_MESSAGE);
+  }
+
+  return amount;
+};
+
+export const parsePositivePenceAmount = (amount: unknown): number => {
+  if (typeof amount === 'number') {
+    return assertPositiveIntegerPence(amount);
+  }
+
+  if (typeof amount === 'string') {
+    const trimmedAmount = amount.trim();
+
+    if (!integerPencePattern.test(trimmedAmount)) {
+      throw new Error(INVALID_PAYMENT_AMOUNT_MESSAGE);
+    }
+
+    return assertPositiveIntegerPence(Number(trimmedAmount));
+  }
+
+  throw new Error(INVALID_PAYMENT_AMOUNT_MESSAGE);
+};


### PR DESCRIPTION
Attempts https://github.com/Cherry-CIC/cherry-Backend/issues/30

## Summary
- Treat `/api/payment/create-payment-intent` amounts as integer pence and pass them to Stripe without multiplying by 100.
- Validate missing, zero, negative, decimal, and non-numeric amounts before creating a PaymentIntent.
- Return both `clientSecret` and the legacy `paymentIntent` alias so the current Flutter flow does not crash while it is migrated.
- Add payment route and repository tests covering exact Stripe payload amounts, invalid inputs, and response shape.

## Testing
- `npm test -- --runTestsByPath src/modules/payment/tests/paymentRepository.test.ts src/modules/payment/tests/paymentRoutes.test.ts`
- `npm run build`
- `npm test -- --no-cache --runInBand`