### PR TITLE
Add postage size data endpoint and product field

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -21,10 +21,12 @@ import paymentRoutes from './modules/payment/routes/paymentRoutes';
 import orderRoutes from './modules/order/routes/orderRoutes';
 import adminRoutes from './modules/order/routes/adminRoutes';
 import shippingRoutes from './modules/shipping/routes/shippingRoutes';
+import postageSizeRoutes from './modules/postageSizes/routes/postageSizeRoutes';
 
 app.use('/api/products', productRoutes);
 app.use('/api/categories', categoryRoutes);
 app.use('/api/charities', charityRoutes);
+app.use('/api/postage-sizes', postageSizeRoutes);
 app.use('/api/auth', authRoutes);
 app.use('/api/payment', paymentRoutes);
 app.use('/api/order', orderRoutes);

--- a/src/modules/postageSizes/controllers/postageSizeController.ts
+++ b/src/modules/postageSizes/controllers/postageSizeController.ts
@@ -1,0 +1,25 @@
+import { Request, Response } from 'express';
+import { ResponseHandler } from '../../../shared/utils/responseHandler';
+import { PostageSizeRepository } from '../repositories/PostageSizeRepository';
+
+const repo = new PostageSizeRepository();
+
+export const getAllPostageSizes = async (
+  req: Request,
+  res: Response,
+): Promise<void> => {
+  try {
+    const postageSizes = await repo.getAll();
+    ResponseHandler.success(
+      res,
+      postageSizes,
+      'Postage sizes fetched successfully',
+    );
+  } catch (err) {
+    ResponseHandler.internalServerError(
+      res,
+      'Failed to fetch postage sizes',
+      err instanceof Error ? err.message : 'Unknown error',
+    );
+  }
+};

--- a/src/modules/postageSizes/model/PostageSize.ts
+++ b/src/modules/postageSizes/model/PostageSize.ts
@@ -1,0 +1,8 @@
+export interface PostageSize {
+  id: string;
+  type: string;
+  size: string;
+  description: string;
+  createdAt?: Date;
+  updatedAt?: Date;
+}

--- a/src/modules/postageSizes/repositories/PostageSizeRepository.ts
+++ b/src/modules/postageSizes/repositories/PostageSizeRepository.ts
@@ -1,0 +1,50 @@
+import { Timestamp } from 'firebase-admin/firestore';
+import { firestore } from '../../../shared/config/firebaseConfig';
+import { PostageSize } from '../model/PostageSize';
+
+const POSTAGE_SIZE_ORDER: Record<string, number> = {
+  small: 1,
+  medium: 2,
+  large: 3,
+};
+
+export class PostageSizeRepository {
+  private collectionName = 'postage_sizes';
+
+  async getAll(): Promise<PostageSize[]> {
+    const snapshot = await firestore.collection(this.collectionName).get();
+
+    return snapshot.docs
+      .map((doc) => this.mapToPostageSize(doc.id, doc.data()))
+      .sort((left, right) => {
+        const leftOrder = POSTAGE_SIZE_ORDER[left.size] ?? Number.MAX_SAFE_INTEGER;
+        const rightOrder = POSTAGE_SIZE_ORDER[right.size] ?? Number.MAX_SAFE_INTEGER;
+        return leftOrder - rightOrder || left.size.localeCompare(right.size);
+      });
+  }
+
+  private mapToPostageSize(id: string, data: any): PostageSize {
+    const size = String(data.size || id || '').toLowerCase();
+
+    return {
+      id,
+      type: String(data.type || data.carrier || 'inpost').toLowerCase(),
+      size,
+      description: data.description || '',
+      createdAt: this.toDate(data.createdAt),
+      updatedAt: this.toDate(data.updatedAt),
+    };
+  }
+
+  private toDate(value: any): Date | undefined {
+    if (!value) {
+      return undefined;
+    }
+
+    if (value instanceof Timestamp || typeof value.toDate === 'function') {
+      return value.toDate();
+    }
+
+    return new Date(value);
+  }
+}

--- a/src/modules/postageSizes/routes/postageSizeRoutes.ts
+++ b/src/modules/postageSizes/routes/postageSizeRoutes.ts
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import { getAllPostageSizes } from '../controllers/postageSizeController';
+
+const router = Router();
+
+router.get('/', getAllPostageSizes);
+
+export default router;

--- a/src/modules/postageSizes/tests/postageSizeRepository.test.ts
+++ b/src/modules/postageSizes/tests/postageSizeRepository.test.ts
@@ -1,0 +1,63 @@
+const mockGet = jest.fn();
+const mockCollection = jest.fn();
+
+jest.mock('../../../shared/config/firebaseConfig', () => ({
+  firestore: {
+    collection: mockCollection,
+  },
+}));
+
+import { PostageSizeRepository } from '../repositories/PostageSizeRepository';
+
+describe('PostageSizeRepository', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCollection.mockReturnValue({
+      get: mockGet,
+    });
+  });
+
+  it('fetches postage sizes from Firestore in the frontend contract shape', async () => {
+    mockGet.mockResolvedValue({
+      docs: [
+        {
+          id: 'medium-id',
+          data: () => ({
+            type: 'inpost',
+            size: 'medium',
+            description: 'Medium parcel',
+          }),
+        },
+        {
+          id: 'small-id',
+          data: () => ({
+            size: 'small',
+            description: 'Small parcel',
+          }),
+        },
+      ],
+    });
+
+    const result = await new PostageSizeRepository().getAll();
+
+    expect(mockCollection).toHaveBeenCalledWith('postage_sizes');
+    expect(result).toEqual([
+      {
+        id: 'small-id',
+        type: 'inpost',
+        size: 'small',
+        description: 'Small parcel',
+        createdAt: undefined,
+        updatedAt: undefined,
+      },
+      {
+        id: 'medium-id',
+        type: 'inpost',
+        size: 'medium',
+        description: 'Medium parcel',
+        createdAt: undefined,
+        updatedAt: undefined,
+      },
+    ]);
+  });
+});

--- a/src/modules/postageSizes/tests/postageSizeRoutes.test.ts
+++ b/src/modules/postageSizes/tests/postageSizeRoutes.test.ts
@@ -1,0 +1,49 @@
+const mockGetAll = jest.fn();
+
+jest.mock('../repositories/PostageSizeRepository', () => ({
+  PostageSizeRepository: jest.fn().mockImplementation(() => ({
+    getAll: mockGetAll,
+  })),
+}));
+
+import express from 'express';
+import request from 'supertest';
+import postageSizeRoutes from '../routes/postageSizeRoutes';
+
+describe('postageSizeRoutes', () => {
+  const app = express();
+  app.use('/api/postage-sizes', postageSizeRoutes);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns postage sizes at GET /api/postage-sizes', async () => {
+    mockGetAll.mockResolvedValue([
+      {
+        id: 'small-id',
+        type: 'inpost',
+        size: 'small',
+        description: 'Small parcel',
+      },
+    ]);
+
+    const response = await request(app).get('/api/postage-sizes');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        success: true,
+        message: 'Postage sizes fetched successfully',
+        data: [
+          {
+            id: 'small-id',
+            type: 'inpost',
+            size: 'small',
+            description: 'Small parcel',
+          },
+        ],
+      }),
+    );
+  });
+});

--- a/src/modules/products/model/Product.ts
+++ b/src/modules/products/model/Product.ts
@@ -7,6 +7,7 @@ export interface Product {
     userId: string;
     quality: string;
     size: string;
+    postage_size?: string;
     product_images: string[];
     donation: number;
     price: number;

--- a/src/modules/products/services/ProductService.ts
+++ b/src/modules/products/services/ProductService.ts
@@ -194,6 +194,7 @@ export interface CreateProductData {
     charityId: string;
     quality: string;
     size: string;
+    postage_size?: string;
     product_images: string[];
     donation: number;
     price: number;
@@ -208,6 +209,7 @@ export interface UpdateProductData {
     charityId?: string;
     quality?: string;
     size?: string;
+    postage_size?: string;
     product_images?: string[];
     donation?: number;
     price?: number;

--- a/src/modules/products/tests/productValidator.test.ts
+++ b/src/modules/products/tests/productValidator.test.ts
@@ -1,0 +1,61 @@
+import { validateProduct } from '../validators/productValidator';
+
+const createResponse = () => {
+  const res: any = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+};
+
+const validProductPayload = {
+  name: 'Winter Coat',
+  description: 'A warm donated coat',
+  categoryId: 'category-1',
+  charityId: 'charity-1',
+  quality: 'Good',
+  size: 'Medium',
+  product_images: ['https://example.com/coat.jpg'],
+  donation: 10,
+  price: 25,
+  likes: 0,
+  number: 1,
+};
+
+describe('productValidator', () => {
+  it('accepts a valid postage_size value', () => {
+    const req: any = {
+      body: {
+        ...validProductPayload,
+        postage_size: 'small',
+      },
+    };
+    const res = createResponse();
+    const next = jest.fn();
+
+    validateProduct(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unsupported postage_size value', () => {
+    const req: any = {
+      body: {
+        ...validProductPayload,
+        postage_size: 'extra_large',
+      },
+    };
+    const res = createResponse();
+    const next = jest.fn();
+
+    validateProduct(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: expect.stringContaining('postage_size'),
+      }),
+    );
+  });
+});

--- a/src/modules/products/validators/productValidator.ts
+++ b/src/modules/products/validators/productValidator.ts
@@ -42,6 +42,13 @@ export const productSchema = Joi.object({
             'any.required': `"size" is required`,
         }),
 
+    postage_size: Joi.string().trim().valid('small', 'medium', 'large').optional()
+        .messages({
+            'string.base': `"postage_size" should be a type of 'text'`,
+            'string.empty': `"postage_size" cannot be empty`,
+            'any.only': `"postage_size" must be one of small, medium or large`,
+        }),
+
     product_images: Joi.array().items(Joi.string().uri()).min(1).required()
         .messages({
             'array.base': `"product_images" should be an array`,


### PR DESCRIPTION
## Summary

- Add public `GET /api/postage-sizes` for the Donate page postage-size selector.
- Read postage size documents from the Firebase `postage_sizes` collection.
- Return the frontend contract shape: `{ success, message, data: [{ id, type, size, description }] }`.
- Allow `/api/products` create/update payloads to include optional `postage_size` values: `small`, `medium`, or `large`.
- Add focused tests for the postage-size endpoint/repository and product `postage_size` validation.

## Why

The frontend Donate/Give page now includes “Size for Posting”. Without a backend postage-size endpoint and product `postage_size` acceptance, the app shows “Unable to fetch data” and item upload can fail when the new field is submitted.

## Scope

This is intentionally a small backend/API PR. It does not include the broader pickup-point delivery, Sendcloud shipment, checkout, payment, or map changes from PR #28.

Files changed are limited to:

- `src/app.ts`
- `src/modules/postageSizes/*`
- `src/modules/products/model/Product.ts`
- `src/modules/products/services/ProductService.ts`
- `src/modules/products/validators/productValidator.ts`
- focused tests under `src/modules/postageSizes/tests` and `src/modules/products/tests`

## Reviewer Notes

- `postage_size` is optional to avoid breaking older product creation clients.
- Firebase must contain `postage_sizes` documents. Expected fields are `type`, `size`, and `description`; `id` comes from the Firestore document ID.
- The repository sorts known sizes as `small`, `medium`, then `large` for stable frontend display.

## Validation

- `npm run build`
- `npm test -- --runInBand` passing: 11 suites, 66 tests
- `git diff --check`

## Related

- Frontend issue context: https://github.com/Cherry-CIC/MVP/issues/423
- This is a focused alternative to the broader backend PR #28 for the postage-size upload blocker.
