### PR TITLE
Allow postage_size on product creation

### DIFF
--- a/src/modules/products/routes/productRoutes.ts
+++ b/src/modules/products/routes/productRoutes.ts
@@ -343,6 +343,11 @@ router.get('/:id/with-details', authMiddleware, validateProductId, getProductWit
  *                 items:
  *                   type: string
  *                 example: ["https://example.com/smartphone1.jpg", "https://example.com/smartphone2.jpg"]
+ *               postage_size:
+ *                 type: string
+ *                 enum: [small, medium, large]
+ *                 description: Selected parcel/postage size for the listed product. Accepted values: small, medium, large.
+ *                 example: "small"
  *               donation:
  *                 type: number
  *                 example: 50.0

--- a/src/modules/products/validators/productValidator.ts
+++ b/src/modules/products/validators/productValidator.ts
@@ -49,6 +49,8 @@ export const productSchema = Joi.object({
             'any.required': `"product_images" is required`,
         }),
 
+    postage_size: Joi.string().valid('small', 'medium', 'large').optional(),
+
     donation: Joi.number().positive().required()
         .messages({
             'number.base': `"donation" should be a number`,


### PR DESCRIPTION
This PR fixes the product upload failure caused by POST /api/products rejecting the postage_size field.

The frontend already sends postage_size during item upload, but the backend validation currently rejects it with: "postage_size is not allowed".

Changes:
- Adds postage_size to the product creation validation schema.
- Restricts postage_size to small, medium or large.
- Documents postage_size in the existing POST /api/products Swagger request schema.

Persistence is handled by the existing product creation flow, which saves the validated request body when creating the product.

This PR does not change Firebase, frontend code, order creation, Sendcloud, shipping logic or weight handling.

Validation:
- Direct Joi schema check passed for small, medium, large, invalid extra_large, and missing postage_size.
- npx tsc --noEmit passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `postage_size` field to product creation. Users can now specify postage sizes as small, medium, or large when creating products.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->