### PR TITLE
Fixes #22: refactor service configs to lazy initialization to prevent GCP Cloud Run startup crashes

### DIFF
--- a/src/modules/order/model/Order.ts
+++ b/src/modules/order/model/Order.ts
@@ -1,5 +1,16 @@
 export type DeliveryType = 'home' | 'pickup_point';
-export type PaymentStatus = 'pending' | 'succeeded' | 'failed';
+// BACKWARDS COMPATIBILITY NOTE (added 2026-05-21):
+// 'processing' was added to PaymentStatus alongside the Stripe webhook hardening.
+// Existing Firestore order documents written before this change will only contain
+// 'pending' | 'succeeded' | 'failed'. The fallback in OrderRepository.getOrdersByDateRange
+// (currently `data.paymentStatus || 'pending'`) safely handles any legacy document
+// that predates this change.
+//
+// TODO (future engineer): Once you are confident no documents with unrecognised
+// paymentStatus values exist in Firestore (e.g. after a data migration or sufficient
+// run-time), you may narrow this type back and remove the || 'pending' fallback.
+export type PaymentStatus = 'pending' | 'processing' | 'succeeded' | 'failed';
+
 export type ShipmentStatus =
   | 'not_created'
   | 'pending'

--- a/src/modules/order/repositories/OrderRepository.ts
+++ b/src/modules/order/repositories/OrderRepository.ts
@@ -128,6 +128,8 @@ export class OrderRepository {
         shippingWeight: data.shippingWeight || 0,
         pickupPoint: data.pickupPoint,
         paymentIntentId: data.paymentIntentId,
+        // BACKWARDS COMPATIBILITY: fall back to 'pending' for legacy documents that
+        // predate the PaymentStatus union expansion. See Order.ts for full note.
         paymentStatus: data.paymentStatus || 'pending',
         shipmentStatus: data.shipmentStatus || 'not_created',
         status: data.status || 'completed',
@@ -136,4 +138,29 @@ export class OrderRepository {
       } as Order;
     });
   }
+
+  /**
+   * Looks up an order by its Stripe PaymentIntent ID.
+   *
+   * Returns null if no matching order is found — this is the expected case when a
+   * webhook fires before the client has called POST /api/order/create (e.g. during
+   * payment_intent.processing). Callers must handle null gracefully and must NOT
+   * create an order from this lookup; order creation is the client's responsibility.
+   */
+  async getOrderByPaymentIntentId(paymentIntentId: string): Promise<Order | null> {
+    const snapshot = await firestore
+      .collection('orders')
+      .where('paymentIntentId', '==', paymentIntentId)
+      .limit(1)
+      .get();
+
+    if (snapshot.empty) {
+      return null;
+    }
+
+    const doc = snapshot.docs[0];
+    const data = doc.data() as Omit<Order, 'id'>;
+    return { id: doc.id, ...data };
+  }
 }
+

--- a/src/modules/order/repositories/OrderRepository.ts
+++ b/src/modules/order/repositories/OrderRepository.ts
@@ -147,7 +147,9 @@ export class OrderRepository {
    * payment_intent.processing). Callers must handle null gracefully and must NOT
    * create an order from this lookup; order creation is the client's responsibility.
    */
-  async getOrderByPaymentIntentId(paymentIntentId: string): Promise<Order | null> {
+  async getOrderByPaymentIntentId(
+    paymentIntentId: string,
+  ): Promise<Order | null> {
     const snapshot = await firestore
       .collection('orders')
       .where('paymentIntentId', '==', paymentIntentId)
@@ -159,8 +161,37 @@ export class OrderRepository {
     }
 
     const doc = snapshot.docs[0];
-    const data = doc.data() as Omit<Order, 'id'>;
-    return { id: doc.id, ...data };
+    const data = doc.data();
+    let createdAt = data.createdAt;
+    if (createdAt && typeof createdAt.toDate === 'function') {
+      createdAt = createdAt.toDate();
+    } else if (createdAt) {
+      createdAt = new Date(createdAt);
+    }
+
+    return {
+      id: doc.id,
+      userId: data.userId || '',
+      email: data.email || '',
+      amount: data.amount || 0,
+      productId: data.productId,
+      productName: data.productName,
+      shipping: data.shipping,
+      deliveryType: data.deliveryType || 'home',
+      shippingOptionId: data.shippingOptionId || '',
+      shippingOptionName: data.shippingOptionName,
+      shippingOptionPrice: data.shippingOptionPrice,
+      shippingCarrier: data.shippingCarrier,
+      shippingWeight: data.shippingWeight || 0,
+      pickupPoint: data.pickupPoint,
+      paymentIntentId: data.paymentIntentId,
+      // BACKWARDS COMPATIBILITY: fall back to 'pending' for legacy documents that
+      // predate the PaymentStatus union expansion. See Order.ts for full note.
+      paymentStatus: data.paymentStatus || 'pending',
+      shipmentStatus: data.shipmentStatus || 'not_created',
+      status: data.status || 'completed',
+      shipmentId: data.shipmentId,
+      createdAt,
+    } as Order;
   }
 }
-

--- a/src/modules/payment/PaymentRepository.ts
+++ b/src/modules/payment/PaymentRepository.ts
@@ -60,6 +60,10 @@ export class PaymentRepository {
       customer.id
     );
 
+    if (!process.env.STRIPE_PUBLISHABLE_KEY) {
+      throw new Error('STRIPE_PUBLISHABLE_KEY is not defined in the environment.');
+    }
+
     return {
       paymentIntentId: paymentIntent.id,
       clientSecret: paymentIntent.client_secret,

--- a/src/modules/payment/PaymentRepository.ts
+++ b/src/modules/payment/PaymentRepository.ts
@@ -24,10 +24,13 @@ export class PaymentRepository {
    * @param currency - Currency code (e.g., usd).
    * @returns An object containing the client secret, ephemeral key, customer ID, and publishable key.
    */
-  async createPaymentIntentForUser(
-    email: string,
-    amount: number
-  ) {
+  async createPaymentIntentForUser(email: string, amount: number) {
+    if (!process.env.STRIPE_PUBLISHABLE_KEY) {
+      throw new Error(
+        'STRIPE_PUBLISHABLE_KEY is not defined in the environment.',
+      );
+    }
+
     // Attempt to find an existing customer by email
     let customer: any;
     try {
@@ -57,12 +60,8 @@ export class PaymentRepository {
     const paymentIntent = await StripeService.createPaymentIntent(
       totalAmount,
       'gbp',
-      customer.id
+      customer.id,
     );
-
-    if (!process.env.STRIPE_PUBLISHABLE_KEY) {
-      throw new Error('STRIPE_PUBLISHABLE_KEY is not defined in the environment.');
-    }
 
     return {
       paymentIntentId: paymentIntent.id,

--- a/src/modules/payment/WebhookEventRepository.ts
+++ b/src/modules/payment/WebhookEventRepository.ts
@@ -8,8 +8,8 @@ const COLLECTION = 'stripe_webhook_events';
  * so 5 minutes gives healthy processing time while still recovering from
  * crashed workers. Override via WEBHOOK_CLAIM_TTL_MS env var.
  */
-const CLAIM_TTL_MS =
-  Number(process.env.WEBHOOK_CLAIM_TTL_MS) || 5 * 60 * 1_000; // 5 min
+const ttlFromEnv = Number(process.env.WEBHOOK_CLAIM_TTL_MS);
+const CLAIM_TTL_MS = Number.isFinite(ttlFromEnv) ? ttlFromEnv : 5 * 60 * 1_000; // 5 min
 
 export type WebhookEventStatus = 'processing' | 'processed';
 

--- a/src/modules/payment/WebhookEventRepository.ts
+++ b/src/modules/payment/WebhookEventRepository.ts
@@ -1,0 +1,201 @@
+import { firestore } from '../../shared/config/firebaseConfig';
+
+const COLLECTION = 'stripe_webhook_events';
+
+/**
+ * How long (milliseconds) a 'processing' claim is considered live before a
+ * subsequent delivery may steal it. Stripe's own retry window is several hours,
+ * so 5 minutes gives healthy processing time while still recovering from
+ * crashed workers. Override via WEBHOOK_CLAIM_TTL_MS env var.
+ */
+const CLAIM_TTL_MS =
+  Number(process.env.WEBHOOK_CLAIM_TTL_MS) || 5 * 60 * 1_000; // 5 min
+
+export type WebhookEventStatus = 'processing' | 'processed';
+
+/**
+ * Result codes returned by `claim()`:
+ *
+ * - `'claimed'`           — This delivery atomically acquired the lock; caller
+ *                           must process the event and then call markAsProcessed,
+ *                           or releaseClaim on failure.
+ * - `'already_processed'` — A previous delivery fully processed the event; the
+ *                           caller must treat it as a duplicate and skip all side
+ *                           effects.
+ * - `'in_progress'`       — Another delivery holds an unexpired lease; the caller
+ *                           must treat it as a duplicate (Stripe will retry and
+ *                           may win the takeover on a later attempt).
+ */
+export type ClaimResult = 'claimed' | 'already_processed' | 'in_progress';
+
+export interface WebhookEventRecord {
+  eventId: string;
+  eventType: string;
+  status: WebhookEventStatus;
+  /** Wall-clock time this delivery first wrote the claim row. */
+  receivedAt: Date;
+  processedAt?: Date;
+  /**
+   * Updated each time a delivery (re-)claims the row.  Used to evaluate lease
+   * staleness on subsequent ALREADY_EXISTS conflicts.
+   */
+  claimedAt: Date;
+}
+
+/**
+ * Provides durable, race-safe idempotency for Stripe webhook events using Firestore.
+ *
+ * Each event is stored as a document whose ID is the Stripe event ID (e.g.
+ * "evt_1AbCdEfG..."). The document ID equals the event ID, so lookups and claims
+ * are O(1) key operations — no collection scans.
+ *
+ * Concurrency model:
+ *   - `claim(eventId, eventType)` uses Firestore `.create()`, which atomically
+ *     fails when the document already exists. Two concurrent webhook deliveries
+ *     of the same event therefore cannot both succeed in claiming — the loser
+ *     receives a thrown error and must inspect the existing row.
+ *   - On ALREADY_EXISTS the loser reads the document and branches:
+ *       • status === 'processed'  → return 'already_processed' (skip all effects).
+ *       • status === 'processing' and claimedAt is fresh → return 'in_progress'
+ *         (another worker holds a valid lease; Stripe will retry later).
+ *       • status === 'processing' and claimedAt is stale → attempt a conditional
+ *         takeover via a Firestore transaction; if the takeover succeeds return
+ *         'claimed'; if another delivery beat us to the takeover return
+ *         'in_progress'.
+ *   - `markAsProcessed` is called ONLY after side effects succeed; it flips the
+ *     document status from 'processing' → 'processed'.
+ *   - `releaseClaim` resets a claim whose side effects failed so Stripe retries
+ *     can re-acquire it (deletes the row; `.create()` on retry works again).
+ *
+ * Firestore collection: `stripe_webhook_events`
+ */
+export class WebhookEventRepository {
+  /**
+   * Atomically attempts to claim the given Stripe event ID for processing.
+   *
+   * Returns a `ClaimResult`:
+   *   - `'claimed'`           — caller must process then markAsProcessed / releaseClaim.
+   *   - `'already_processed'` — terminal duplicate; skip all side effects.
+   *   - `'in_progress'`       — another delivery holds a live lease; skip side effects.
+   */
+  async claim(eventId: string, eventType: string): Promise<ClaimResult> {
+    const now = new Date();
+    const record: WebhookEventRecord = {
+      eventId,
+      eventType,
+      status: 'processing',
+      receivedAt: now,
+      claimedAt: now,
+    };
+
+    try {
+      await firestore.collection(COLLECTION).doc(eventId).create(record);
+      return 'claimed';
+    } catch (err: any) {
+      // Firestore admin SDK raises ALREADY_EXISTS (gRPC code 6) when create()
+      // is called on an existing document. Any other error must propagate so the
+      // controller can return 500 and let Stripe retry.
+      if (!(err && (err.code === 6 || err.code === 'already-exists'))) {
+        throw err;
+      }
+    }
+
+    // ── ALREADY_EXISTS path ──────────────────────────────────────────────────
+    // Another delivery (or a previous attempt) created the row first. Read it
+    // to decide whether we can take over, must yield, or can skip entirely.
+    const snap = await firestore.collection(COLLECTION).doc(eventId).get();
+
+    if (!snap.exists) {
+      // Document vanished between the failed create() and the get() — extremely
+      // rare (concurrent releaseClaim). Treat as "not yet claimed" and let the
+      // caller retry; propagate as an error so Stripe retries delivery.
+      throw new Error(
+        `WebhookEventRepository: document ${eventId} disappeared during claim read`,
+      );
+    }
+
+    const existing = snap.data() as WebhookEventRecord;
+
+    if (existing.status === 'processed') {
+      return 'already_processed';
+    }
+
+    // status === 'processing': check lease age.
+    const leaseAge =
+      now.getTime() -
+      (existing.claimedAt instanceof Date
+        ? existing.claimedAt.getTime()
+        : (existing.claimedAt as any).toDate().getTime());
+
+    if (leaseAge < CLAIM_TTL_MS) {
+      // Lease is still fresh — another worker is actively processing.
+      return 'in_progress';
+    }
+
+    // Stale lease: attempt a conditional takeover inside a transaction so that
+    // two concurrent takeover attempts cannot both win.
+    const docRef = firestore.collection(COLLECTION).doc(eventId);
+    try {
+      const tookOver = await firestore.runTransaction(async (tx) => {
+        const txSnap = await tx.get(docRef);
+        if (!txSnap.exists) {
+          // Vanished mid-flight — treat as lost; the caller should retry.
+          return false;
+        }
+        const txData = txSnap.data() as WebhookEventRecord;
+        if (txData.status === 'processed') {
+          // Another delivery finished while we were spinning — yield.
+          return false;
+        }
+        // Re-check staleness inside the transaction to avoid a race between
+        // two simultaneous takeover attempts.
+        const txAge =
+          now.getTime() -
+          (txData.claimedAt instanceof Date
+            ? txData.claimedAt.getTime()
+            : (txData.claimedAt as any).toDate().getTime());
+        if (txAge < CLAIM_TTL_MS) {
+          // Another delivery renewed the lease between our read and here.
+          return false;
+        }
+        tx.update(docRef, {
+          status: 'processing',
+          claimedAt: now,
+        } satisfies Partial<WebhookEventRecord>);
+        return true;
+      });
+
+      return tookOver ? 'claimed' : 'in_progress';
+    } catch (txErr: any) {
+      // Transaction failure (e.g. contention abort) — be conservative and
+      // yield; the next Stripe retry can attempt the takeover again.
+      console.warn(
+        `[WebhookEventRepository] Takeover transaction failed for ${eventId}:`,
+        txErr,
+      );
+      return 'in_progress';
+    }
+  }
+
+  /**
+   * Marks an event whose claim was acquired as fully processed. Call this only
+   * AFTER all side effects for the event have been successfully applied.
+   */
+  async markAsProcessed(eventId: string, eventType: string): Promise<void> {
+    await firestore.collection(COLLECTION).doc(eventId).update({
+      eventType,
+      status: 'processed',
+      processedAt: new Date(),
+    });
+  }
+
+  /**
+   * Removes a claim row whose side-effect processing failed. Stripe will retry
+   * the webhook, and the retry will be free to claim the event again via
+   * `.create()`. Must be called whenever business logic throws after a
+   * successful `claim()`.
+   */
+  async releaseClaim(eventId: string): Promise<void> {
+    await firestore.collection(COLLECTION).doc(eventId).delete();
+  }
+}

--- a/src/modules/payment/controllers/paymentController.ts
+++ b/src/modules/payment/controllers/paymentController.ts
@@ -1,6 +1,9 @@
 import { Request, Response } from 'express';
 import { ResponseHandler } from '../../../shared/utils/responseHandler';
-import { createWebhook } from '../../../shared/config/stripeConfig';
+import {
+  createWebhook,
+  WebhookConfigError,
+} from '../../../shared/config/stripeConfig';
 import { PaymentService } from '../services/PaymentService';
 import { WebhookService } from '../services/WebhookService';
 import { WebhookEventRepository } from '../WebhookEventRepository';
@@ -124,6 +127,17 @@ export const stripeWebhook = async (
     // req.body is the raw Buffer provided by express.raw() in paymentRoutes.ts.
     event = createWebhook(req.body as Buffer, sig);
   } catch (err) {
+    if (err instanceof WebhookConfigError) {
+      console.error(
+        `[Webhook] Rejected: server config error. Error: ${err.message}`,
+      );
+      ResponseHandler.internalServerError(
+        res,
+        'Webhook configuration error',
+        err.message,
+      );
+      return;
+    }
     // constructEvent throws when the signature is invalid or the payload is
     // malformed. This is not a server error — return 400 so Stripe stops retrying.
     console.warn(
@@ -175,12 +189,11 @@ export const stripeWebhook = async (
 
   if (claimResult === 'in_progress') {
     console.log(
-      `[Webhook] Duplicate event ignored (claim in progress): ${event.type} (id: ${event.id})`,
+      `[Webhook] Duplicate delivery received while another worker is processing: ${event.type} (id: ${event.id})`,
     );
-    // Another delivery holds a live lease. Return 200 so Stripe does not
-    // immediately retry; Stripe's own retry schedule will re-deliver if the
-    // current holder crashes and the lease goes stale.
-    ResponseHandler.success(res, { received: true }, 'Event already in progress');
+    // Return a non-2xx so Stripe retries later. This prevents a crash-after-claim
+    // scenario from being treated as a successful delivery.
+    ResponseHandler.conflict(res, 'Webhook event is currently being processed');
     return;
   }
 

--- a/src/modules/payment/controllers/paymentController.ts
+++ b/src/modules/payment/controllers/paymentController.ts
@@ -1,8 +1,9 @@
 import { Request, Response } from 'express';
 import { ResponseHandler } from '../../../shared/utils/responseHandler';
 import { createWebhook } from '../../../shared/config/stripeConfig';
-import { authMiddleware } from '../../../shared/middleware/authMiddleWare';
 import { PaymentService } from '../services/PaymentService';
+import { WebhookService } from '../services/WebhookService';
+import { WebhookEventRepository } from '../WebhookEventRepository';
 
 /**
  * @swagger
@@ -54,53 +55,172 @@ import { PaymentService } from '../services/PaymentService';
  *       500:
  *         description: Internal server error
  */
-export const createPaymentIntent = async (req: Request, res: Response): Promise<void> => {
+export const createPaymentIntent = async (
+  req: Request,
+  res: Response,
+): Promise<void> => {
   try {
     const user = (req as any).user;
     const firebaseUid = user.uid;
-  
+
     // Extract amount (currency is fixed to GBP)
     const { amount } = req.body;
-  
+
     // Use service to handle Stripe logic and reuse existing customers when possible
     const paymentService = new PaymentService();
-    const responseData = await paymentService.createPaymentIntentForUserByUid(firebaseUid, amount);
+    const responseData = await paymentService.createPaymentIntentForUserByUid(
+      firebaseUid,
+      amount,
+    );
 
     ResponseHandler.success(res, responseData, 'PaymentIntent created');
   } catch (err) {
     ResponseHandler.internalServerError(
       res,
       'Failed to create PaymentIntent',
-      err instanceof Error ? err.message : 'Unknown error'
+      err instanceof Error ? err.message : 'Unknown error',
     );
   }
 };
- 
-// Stripe webhook endpoint (moved from webhookController)
-export const stripeWebhook = async (req: Request, res: Response): Promise<void> => {
+
+/**
+ * POST /api/payment/webhook
+ *
+ * Stripe webhook endpoint. Handles the following subscribed events:
+ *   - payment_intent.succeeded
+ *   - payment_intent.processing
+ *   - payment_intent.payment_failed
+ *   - payment_intent.canceled
+ *
+ * Security:
+ *   - Signature is verified using stripe.webhooks.constructEvent with
+ *     STRIPE_WEBHOOK_SECRET. Invalid signatures return 400 immediately.
+ *
+ * Idempotency:
+ *   - Each Stripe event ID is stored in Firestore after successful processing.
+ *   - Duplicate event deliveries (Stripe retries) return 200 immediately without
+ *     repeating any side effects.
+ *
+ * Error handling:
+ *   - 400: missing or invalid Stripe signature
+ *   - 200: valid event processed (or safely skipped as duplicate/unsupported)
+ *   - 500: unexpected internal error (Stripe will retry; event NOT marked processed)
+ */
+export const stripeWebhook = async (
+  req: Request,
+  res: Response,
+): Promise<void> => {
+  // ── Step 1: Verify the Stripe signature ──────────────────────────────────────
+  const sig = req.headers['stripe-signature'] as string | undefined;
+
+  if (!sig) {
+    console.warn('[Webhook] Rejected: missing stripe-signature header.');
+    ResponseHandler.badRequest(res, 'Missing Stripe signature header');
+    return;
+  }
+
+  let event;
   try {
-    const sig = req.headers['stripe-signature'] as string;
-    if (!sig) {
-      ResponseHandler.badRequest(res, 'Missing Stripe signature header');
-      return;
-    }
-
-    // Raw body is required for signature verification
-    const rawBody = (req as any).rawBody || req.body;
-    const event = createWebhook(rawBody, sig);
-
-    // Example handling – extend as needed
-    if (event.type === 'payment_intent.succeeded') {
-      console.log('✅ Payment succeeded:', (event.data.object as any).id);
-    }
-
-    ResponseHandler.success(res, {}, 'Webhook received');
+    // req.body is the raw Buffer provided by express.raw() in paymentRoutes.ts.
+    event = createWebhook(req.body as Buffer, sig);
   } catch (err) {
-    console.error('⚠️ Webhook error:', err);
+    // constructEvent throws when the signature is invalid or the payload is
+    // malformed. This is not a server error — return 400 so Stripe stops retrying.
+    console.warn(
+      `[Webhook] Rejected: invalid signature. Error: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    ResponseHandler.badRequest(
+      res,
+      'Invalid webhook signature',
+      err instanceof Error ? err.message : 'Signature verification failed',
+    );
+    return;
+  }
+
+  console.log(`[Webhook] Received event: ${event.type} (id: ${event.id})`);
+
+  // ── Step 2: Atomically claim the event for processing ────────────────────────
+  // We use a single atomic Firestore create() to claim the event. This is the
+  // only race-safe way to dedupe under concurrent Stripe deliveries — a
+  // check-then-set would allow two simultaneous requests to both pass the check
+  // and double-process. If the claim fails because another delivery already
+  // holds it (processing OR already processed), this delivery is a duplicate.
+  const webhookEventRepo = new WebhookEventRepository();
+
+  let claimResult: import('../WebhookEventRepository').ClaimResult;
+  try {
+    claimResult = await webhookEventRepo.claim(event.id, event.type);
+  } catch (err) {
+    // Firestore write failure (not an idempotency signal — those return a
+    // ClaimResult string). Return 500 so Stripe retries.
+    console.error(
+      `[Webhook] Failed to claim event ${event.id} for processing:`,
+      err,
+    );
     ResponseHandler.internalServerError(
       res,
-      'Failed to process webhook',
-      err instanceof Error ? err.message : 'Unknown error'
+      'Webhook idempotency check failed',
+      err instanceof Error ? err.message : 'Unknown error',
+    );
+    return;
+  }
+
+  if (claimResult === 'already_processed') {
+    console.log(
+      `[Webhook] Duplicate event ignored (already processed): ${event.type} (id: ${event.id})`,
+    );
+    ResponseHandler.success(res, { received: true }, 'Duplicate event ignored');
+    return;
+  }
+
+  if (claimResult === 'in_progress') {
+    console.log(
+      `[Webhook] Duplicate event ignored (claim in progress): ${event.type} (id: ${event.id})`,
+    );
+    // Another delivery holds a live lease. Return 200 so Stripe does not
+    // immediately retry; Stripe's own retry schedule will re-deliver if the
+    // current holder crashes and the lease goes stale.
+    ResponseHandler.success(res, { received: true }, 'Event already in progress');
+    return;
+  }
+
+  // ── Step 3: Process the event ─────────────────────────────────────────────────
+  try {
+    const webhookService = new WebhookService();
+    await webhookService.handleStripeEvent(event);
+
+    // Mark as processed ONLY after successful side effects. If handleStripeEvent
+    // throws we release the claim below so Stripe's retry can re-acquire it.
+    await webhookEventRepo.markAsProcessed(event.id, event.type);
+
+    console.log(
+      `[Webhook] Successfully processed event: ${event.type} (id: ${event.id})`,
+    );
+    ResponseHandler.success(res, { received: true }, 'Webhook processed');
+  } catch (err) {
+    // Business logic or the final Firestore write failed. Release the claim so
+    // the next Stripe retry can re-claim and re-process. WebhookService handlers
+    // are individually idempotent (no-op when the target state is already set),
+    // so partial side effects from this attempt remain safe under retry.
+    console.error(
+      `[Webhook] Unexpected error processing event ${event.type} (id: ${event.id}):`,
+      err,
+    );
+    try {
+      await webhookEventRepo.releaseClaim(event.id);
+    } catch (releaseErr) {
+      // If we cannot release the claim, the event will be blocked from
+      // reprocessing until the claim row is removed manually. Log loudly so
+      // operators can intervene; do not mask the original error.
+      console.error(
+        `[Webhook] Failed to release claim for event ${event.id} after processing error. Manual cleanup of stripe_webhook_events/${event.id} may be required:`,
+        releaseErr,
+      );
+    }
+    ResponseHandler.internalServerError(
+      res,
+      'Failed to process webhook event',
+      err instanceof Error ? err.message : 'Unknown error',
     );
   }
 };

--- a/src/modules/payment/services/WebhookService.ts
+++ b/src/modules/payment/services/WebhookService.ts
@@ -1,0 +1,253 @@
+import Stripe from 'stripe';
+import { OrderRepository } from '../../order/repositories/OrderRepository';
+
+/**
+ * Implements idempotent, safe business logic for each subscribed Stripe payment
+ * event type. All methods are designed to be called at most once per event ID
+ * (idempotency is enforced at the controller layer via WebhookEventRepository).
+ *
+ * Design contract:
+ *   - This service NEVER creates orders. Orders are created exclusively by the
+ *     client via POST /api/order/create after confirming payment. The webhook
+ *     is for reconciliation and state correction only.
+ *   - Every handler must be safe to run even when no matching order exists in
+ *     Firestore (Stripe may deliver an event before the client has called the
+ *     order endpoint). In that case, the handler logs and returns without error.
+ *   - Partial order updates use updateOrder with only the fields that must change,
+ *     so no other fields are touched.
+ */
+export class WebhookService {
+  private orderRepo = new OrderRepository();
+
+  /**
+   * Routes a verified, non-duplicate Stripe event to the appropriate handler.
+   * Unsupported event types are logged and silently ignored — they do not
+   * cause an error so Stripe receives a 200 and stops retrying.
+   */
+  async handleStripeEvent(event: Stripe.Event): Promise<void> {
+    const paymentIntent = event.data.object as Stripe.PaymentIntent;
+
+    switch (event.type) {
+      case 'payment_intent.succeeded':
+        await this.handlePaymentSucceeded(paymentIntent);
+        break;
+
+      case 'payment_intent.processing':
+        await this.handlePaymentProcessing(paymentIntent);
+        break;
+
+      case 'payment_intent.payment_failed':
+        await this.handlePaymentFailed(paymentIntent);
+        break;
+
+      case 'payment_intent.canceled':
+        await this.handlePaymentCanceled(paymentIntent);
+        break;
+
+      default:
+        // Unsupported event types are not an error — they are intentionally
+        // ignored. Returning normally ensures Stripe receives 200 and does not
+        // retry. New event types should be added here when subscribed in Stripe.
+        console.log(
+          `[WebhookService] Unsupported event type received and safely ignored: ${event.type} (id: ${event.id})`,
+        );
+        break;
+    }
+  }
+
+  /**
+   * payment_intent.succeeded
+   *
+   * The payment has been captured. If an order for this PaymentIntent exists and
+   * its paymentStatus is not already 'succeeded', update it to 'succeeded'.
+   *
+   * Safe behaviour:
+   *   - No-op if the order does not exist yet (client has not called /api/order).
+   *   - No-op if paymentStatus is already 'succeeded' (prevents double-processing
+   *     on Stripe retries, even if the idempotency check in the controller is
+   *     bypassed or the event is reprocessed for any reason).
+   *   - Does NOT create or delete any order.
+   */
+  private async handlePaymentSucceeded(
+    paymentIntent: Stripe.PaymentIntent,
+  ): Promise<void> {
+    console.log(
+      `[WebhookService] payment_intent.succeeded — paymentIntentId: ${paymentIntent.id}`,
+    );
+
+    const order = await this.orderRepo.getOrderByPaymentIntentId(
+      paymentIntent.id,
+    );
+
+    if (!order) {
+      // This is expected when the webhook fires before the client creates the order.
+      // The order controller already verifies payment status before creating the order,
+      // so this is safe to ignore.
+      console.log(
+        `[WebhookService] payment_intent.succeeded — no order found for paymentIntentId: ${paymentIntent.id}. No action taken.`,
+      );
+      return;
+    }
+
+    if (order.paymentStatus === 'succeeded') {
+      console.log(
+        `[WebhookService] payment_intent.succeeded — order ${order.id} already marked succeeded. No action taken.`,
+      );
+      return;
+    }
+
+    await this.orderRepo.updateOrder(order.id, {
+      paymentStatus: 'succeeded',
+      status: 'completed',
+    });
+
+    console.log(
+      `[WebhookService] payment_intent.succeeded — order ${order.id} updated to paymentStatus: succeeded.`,
+    );
+  }
+
+  /**
+   * payment_intent.processing
+   *
+   * Stripe is processing the payment (e.g. bank transfer, delayed settlement).
+   * The outcome is not yet known. This MUST NOT mark the order as complete.
+   *
+   * Safe behaviour:
+   *   - No-op if no order exists for this PaymentIntent.
+   *   - Updates paymentStatus to 'processing' only if the order is currently
+   *     'pending' — prevents rolling back a 'succeeded' or 'failed' order.
+   *   - Does NOT create or fulfil any order.
+   */
+  private async handlePaymentProcessing(
+    paymentIntent: Stripe.PaymentIntent,
+  ): Promise<void> {
+    console.log(
+      `[WebhookService] payment_intent.processing — paymentIntentId: ${paymentIntent.id}`,
+    );
+
+    const order = await this.orderRepo.getOrderByPaymentIntentId(
+      paymentIntent.id,
+    );
+
+    if (!order) {
+      console.log(
+        `[WebhookService] payment_intent.processing — no order found for paymentIntentId: ${paymentIntent.id}. No action taken.`,
+      );
+      return;
+    }
+
+    if (order.paymentStatus !== 'pending') {
+      // Do not overwrite a terminal or already-advanced state with 'processing'.
+      console.log(
+        `[WebhookService] payment_intent.processing — order ${order.id} has paymentStatus '${order.paymentStatus}', not overwriting with 'processing'.`,
+      );
+      return;
+    }
+
+    await this.orderRepo.updateOrder(order.id, {
+      paymentStatus: 'processing',
+    });
+
+    console.log(
+      `[WebhookService] payment_intent.processing — order ${order.id} updated to paymentStatus: processing.`,
+    );
+  }
+
+  /**
+   * payment_intent.payment_failed
+   *
+   * The payment attempt has failed. The user may retry with a new PaymentIntent.
+   *
+   * Safe behaviour:
+   *   - No-op if no order exists (the client should not have created one yet for
+   *     a failed payment, but we guard defensively).
+   *   - Updates order to paymentStatus: 'failed', status: 'failed' only if the
+   *     order is not already in a terminal succeeded state.
+   *   - Does NOT delete, refund, or create any record.
+   */
+  private async handlePaymentFailed(
+    paymentIntent: Stripe.PaymentIntent,
+  ): Promise<void> {
+    console.log(
+      `[WebhookService] payment_intent.payment_failed — paymentIntentId: ${paymentIntent.id}`,
+    );
+
+    const order = await this.orderRepo.getOrderByPaymentIntentId(
+      paymentIntent.id,
+    );
+
+    if (!order) {
+      console.log(
+        `[WebhookService] payment_intent.payment_failed — no order found for paymentIntentId: ${paymentIntent.id}. No action taken.`,
+      );
+      return;
+    }
+
+    if (order.paymentStatus === 'succeeded') {
+      // Defensive guard: do not overwrite a succeeded order with failed.
+      // This should not occur in normal Stripe flows but prevents data corruption
+      // if events arrive severely out-of-order.
+      console.warn(
+        `[WebhookService] payment_intent.payment_failed — order ${order.id} is already succeeded. Not overwriting. Manual review recommended.`,
+      );
+      return;
+    }
+
+    await this.orderRepo.updateOrder(order.id, {
+      paymentStatus: 'failed',
+      status: 'failed',
+    });
+
+    console.log(
+      `[WebhookService] payment_intent.payment_failed — order ${order.id} updated to paymentStatus: failed.`,
+    );
+  }
+
+  /**
+   * payment_intent.canceled
+   *
+   * The PaymentIntent was canceled (by the server, the client, or Stripe).
+   * Treat the same as a failed payment for order state purposes.
+   *
+   * Safe behaviour:
+   *   - No-op if no order exists.
+   *   - Updates order to paymentStatus: 'failed', status: 'failed' only if the
+   *     order has not already succeeded.
+   *   - Does NOT delete, refund, or create any record.
+   */
+  private async handlePaymentCanceled(
+    paymentIntent: Stripe.PaymentIntent,
+  ): Promise<void> {
+    console.log(
+      `[WebhookService] payment_intent.canceled — paymentIntentId: ${paymentIntent.id}`,
+    );
+
+    const order = await this.orderRepo.getOrderByPaymentIntentId(
+      paymentIntent.id,
+    );
+
+    if (!order) {
+      console.log(
+        `[WebhookService] payment_intent.canceled — no order found for paymentIntentId: ${paymentIntent.id}. No action taken.`,
+      );
+      return;
+    }
+
+    if (order.paymentStatus === 'succeeded') {
+      // Defensive guard: a cancellation after capture would need manual review.
+      console.warn(
+        `[WebhookService] payment_intent.canceled — order ${order.id} is already succeeded. Not overwriting. Manual review recommended.`,
+      );
+      return;
+    }
+
+    await this.orderRepo.updateOrder(order.id, {
+      paymentStatus: 'failed',
+      status: 'failed',
+    });
+
+    console.log(
+      `[WebhookService] payment_intent.canceled — order ${order.id} updated to paymentStatus: failed.`,
+    );
+  }
+}

--- a/src/modules/payment/tests/WebhookEventRepository.test.ts
+++ b/src/modules/payment/tests/WebhookEventRepository.test.ts
@@ -1,0 +1,318 @@
+// Verifies the real WebhookEventRepository against a mocked Firestore. Targets
+// the atomic-claim race fix: the only safe primitive is documentRef.create(),
+// which fails with ALREADY_EXISTS when the document is already present.
+//
+// These tests assert on the Firestore call shape, not on the implementation's
+// internal helpers, so they catch regressions to the atomicity guarantee — e.g.
+// a future refactor that reverts to get()-then-set() will fail here.
+
+const mockCreate = jest.fn();
+const mockUpdate = jest.fn();
+const mockDelete = jest.fn();
+const mockGet = jest.fn();
+const mockDoc = jest.fn(() => ({
+  create: mockCreate,
+  update: mockUpdate,
+  delete: mockDelete,
+  get: mockGet,
+}));
+const mockCollection = jest.fn(() => ({ doc: mockDoc }));
+
+// runTransaction receives a callback; execute it immediately with a mock transaction.
+const mockTxGet = jest.fn();
+const mockTxUpdate = jest.fn();
+const mockRunTransaction = jest.fn(async (cb: (tx: any) => Promise<any>) =>
+  cb({ get: mockTxGet, update: mockTxUpdate }),
+);
+
+jest.mock('../../../shared/config/firebaseConfig', () => ({
+  firestore: {
+    collection: mockCollection,
+    runTransaction: mockRunTransaction,
+  },
+}));
+
+import { WebhookEventRepository } from '../WebhookEventRepository';
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+/** Returns a Firestore-style Timestamp-like object for a given Date. */
+const tsLike = (d: Date) => ({ toDate: () => d });
+
+/** Returns a mock document snapshot containing the given data. */
+const snap = (data: Record<string, any>) => ({
+  exists: true,
+  data: () => data,
+});
+
+const missingSnap = () => ({ exists: false, data: () => undefined });
+
+describe('WebhookEventRepository', () => {
+  let repo: WebhookEventRepository;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    repo = new WebhookEventRepository();
+  });
+
+  // ── claim() ────────────────────────────────────────────────────────────────
+
+  describe('claim()', () => {
+    it('uses documentRef.create() (atomic) — not get-then-set', async () => {
+      mockCreate.mockResolvedValue(undefined);
+
+      await repo.claim('evt_abc', 'payment_intent.succeeded');
+
+      // The race fix depends on .create() — fail loudly if a refactor swaps it
+      // back to .set() or get()-then-set().
+      expect(mockCollection).toHaveBeenCalledWith('stripe_webhook_events');
+      expect(mockDoc).toHaveBeenCalledWith('evt_abc');
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+
+      const record = mockCreate.mock.calls[0][0];
+      expect(record).toMatchObject({
+        eventId: 'evt_abc',
+        eventType: 'payment_intent.succeeded',
+        status: 'processing',
+      });
+      expect(record.receivedAt).toBeInstanceOf(Date);
+      expect(record.claimedAt).toBeInstanceOf(Date);
+    });
+
+    it("returns 'claimed' when the create succeeds (first delivery)", async () => {
+      mockCreate.mockResolvedValue(undefined);
+
+      const result = await repo.claim('evt_001', 'payment_intent.succeeded');
+
+      expect(result).toBe('claimed');
+    });
+
+    it("returns 'already_processed' when existing doc has status 'processed' (numeric code 6)", async () => {
+      const err: any = new Error('Document already exists');
+      err.code = 6;
+      mockCreate.mockRejectedValue(err);
+      mockGet.mockResolvedValue(
+        snap({ status: 'processed', claimedAt: tsLike(new Date()) }),
+      );
+
+      const result = await repo.claim('evt_002', 'payment_intent.succeeded');
+
+      expect(result).toBe('already_processed');
+    });
+
+    it("returns 'already_processed' when existing doc has status 'processed' (string 'already-exists' code)", async () => {
+      const err: any = new Error('Document already exists');
+      err.code = 'already-exists';
+      mockCreate.mockRejectedValue(err);
+      mockGet.mockResolvedValue(
+        snap({ status: 'processed', claimedAt: tsLike(new Date()) }),
+      );
+
+      const result = await repo.claim('evt_003', 'payment_intent.succeeded');
+
+      expect(result).toBe('already_processed');
+    });
+
+    it("returns 'in_progress' when lease is fresh (claimedAt < TTL)", async () => {
+      const err: any = new Error('Document already exists');
+      err.code = 6;
+      mockCreate.mockRejectedValue(err);
+
+      // claimedAt is 1 second ago — well within the 5-minute TTL.
+      const recentClaim = new Date(Date.now() - 1_000);
+      mockGet.mockResolvedValue(
+        snap({ status: 'processing', claimedAt: tsLike(recentClaim) }),
+      );
+
+      const result = await repo.claim('evt_004', 'payment_intent.succeeded');
+
+      expect(result).toBe('in_progress');
+      // No takeover transaction should be attempted for a fresh lease.
+      expect(mockRunTransaction).not.toHaveBeenCalled();
+    });
+
+    it("takes over a stale lease and returns 'claimed'", async () => {
+      const createErr: any = new Error('Document already exists');
+      createErr.code = 6;
+      mockCreate.mockRejectedValue(createErr);
+
+      // claimedAt is 10 minutes ago — stale.
+      const staleClaim = new Date(Date.now() - 10 * 60 * 1_000);
+      mockGet.mockResolvedValue(
+        snap({ status: 'processing', claimedAt: tsLike(staleClaim) }),
+      );
+
+      // Transaction: txGet returns the same stale doc; update succeeds.
+      mockTxGet.mockResolvedValue(
+        snap({ status: 'processing', claimedAt: tsLike(staleClaim) }),
+      );
+      mockTxUpdate.mockReturnValue(undefined);
+      // mockRunTransaction already executes the callback — no additional setup needed.
+
+      const result = await repo.claim('evt_005', 'payment_intent.succeeded');
+
+      expect(result).toBe('claimed');
+      expect(mockRunTransaction).toHaveBeenCalledTimes(1);
+      expect(mockTxUpdate).toHaveBeenCalledTimes(1);
+      const updateArgs = mockTxUpdate.mock.calls[0][1];
+      expect(updateArgs.status).toBe('processing');
+      expect(updateArgs.claimedAt).toBeInstanceOf(Date);
+    });
+
+    it("yields 'in_progress' when another delivery renews lease inside the transaction", async () => {
+      const createErr: any = new Error('Document already exists');
+      createErr.code = 6;
+      mockCreate.mockRejectedValue(createErr);
+
+      // Initial read: stale.
+      const staleClaim = new Date(Date.now() - 10 * 60 * 1_000);
+      mockGet.mockResolvedValue(
+        snap({ status: 'processing', claimedAt: tsLike(staleClaim) }),
+      );
+
+      // Inside transaction: another delivery has already renewed the lease.
+      const freshClaim = new Date(Date.now() - 500);
+      mockTxGet.mockResolvedValue(
+        snap({ status: 'processing', claimedAt: tsLike(freshClaim) }),
+      );
+
+      const result = await repo.claim('evt_006', 'payment_intent.succeeded');
+
+      expect(result).toBe('in_progress');
+      expect(mockTxUpdate).not.toHaveBeenCalled();
+    });
+
+    it("yields 'in_progress' when the transaction itself fails (contention)", async () => {
+      const createErr: any = new Error('Document already exists');
+      createErr.code = 6;
+      mockCreate.mockRejectedValue(createErr);
+
+      const staleClaim = new Date(Date.now() - 10 * 60 * 1_000);
+      mockGet.mockResolvedValue(
+        snap({ status: 'processing', claimedAt: tsLike(staleClaim) }),
+      );
+
+      mockRunTransaction.mockRejectedValue(new Error('Transaction contention'));
+
+      const result = await repo.claim('evt_007', 'payment_intent.succeeded');
+
+      expect(result).toBe('in_progress');
+    });
+
+    it('rethrows non-ALREADY_EXISTS errors (so the controller can return 500)', async () => {
+      // A transient Firestore failure must NOT be silently swallowed as a
+      // duplicate — that would risk dropping real events.
+      const err: any = new Error('Firestore unavailable');
+      err.code = 14; // UNAVAILABLE
+      mockCreate.mockRejectedValue(err);
+
+      await expect(
+        repo.claim('evt_008', 'payment_intent.succeeded'),
+      ).rejects.toThrow('Firestore unavailable');
+    });
+
+    it('rethrows errors with no code property', async () => {
+      // Defensive: an error without err.code is not a duplicate signal.
+      mockCreate.mockRejectedValue(new Error('Network blip'));
+
+      await expect(
+        repo.claim('evt_009', 'payment_intent.succeeded'),
+      ).rejects.toThrow('Network blip');
+    });
+
+    it('rethrows when document vanishes between create() failure and get()', async () => {
+      const createErr: any = new Error('Document already exists');
+      createErr.code = 6;
+      mockCreate.mockRejectedValue(createErr);
+      mockGet.mockResolvedValue(missingSnap());
+
+      await expect(
+        repo.claim('evt_010', 'payment_intent.succeeded'),
+      ).rejects.toThrow(/disappeared during claim read/);
+    });
+
+    it('simulates a real concurrent race: only one of two simultaneous claims wins', async () => {
+      // Real-world scenario: Stripe delivers the same event twice in <100ms.
+      // The Firestore behaviour we mock here is: the first .create() succeeds,
+      // the second fails with ALREADY_EXISTS. The repo must report exactly one
+      // winner.
+      let callCount = 0;
+      mockCreate.mockImplementation(() => {
+        callCount += 1;
+        if (callCount === 1) {
+          return Promise.resolve();
+        }
+        const err: any = new Error('Document already exists');
+        err.code = 6;
+        return Promise.reject(err);
+      });
+
+      // The losing delivery will read the doc (fresh claimedAt → 'in_progress').
+      mockGet.mockResolvedValue(
+        snap({ status: 'processing', claimedAt: tsLike(new Date()) }),
+      );
+
+      const [first, second] = await Promise.all([
+        repo.claim('evt_race', 'payment_intent.succeeded'),
+        repo.claim('evt_race', 'payment_intent.succeeded'),
+      ]);
+
+      const winners = [first, second].filter((r) => r === 'claimed');
+      expect(winners).toHaveLength(1);
+      expect(mockCreate).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // ── markAsProcessed() ─────────────────────────────────────────────────────
+
+  describe('markAsProcessed()', () => {
+    it('updates the existing claim row to status=processed and stamps processedAt', async () => {
+      mockUpdate.mockResolvedValue(undefined);
+
+      await repo.markAsProcessed('evt_010', 'payment_intent.succeeded');
+
+      expect(mockCollection).toHaveBeenCalledWith('stripe_webhook_events');
+      expect(mockDoc).toHaveBeenCalledWith('evt_010');
+      expect(mockUpdate).toHaveBeenCalledTimes(1);
+
+      const update = mockUpdate.mock.calls[0][0];
+      expect(update.eventType).toBe('payment_intent.succeeded');
+      expect(update.status).toBe('processed');
+      expect(update.processedAt).toBeInstanceOf(Date);
+    });
+
+    it('uses .update() not .set() — so it cannot accidentally create a row that bypassed claim()', async () => {
+      mockUpdate.mockResolvedValue(undefined);
+
+      await repo.markAsProcessed('evt_011', 'payment_intent.succeeded');
+
+      // Hard guarantee: if a refactor swaps update() for set(), this test fails.
+      // .set() would silently create the doc if claim() was skipped, which would
+      // mean a "processed" row exists without the claim contention check ever
+      // running.
+      expect(mockUpdate).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ── releaseClaim() ────────────────────────────────────────────────────────
+
+  describe('releaseClaim()', () => {
+    it('deletes the claim row so Stripe retries can re-acquire it', async () => {
+      mockDelete.mockResolvedValue(undefined);
+
+      await repo.releaseClaim('evt_020');
+
+      expect(mockCollection).toHaveBeenCalledWith('stripe_webhook_events');
+      expect(mockDoc).toHaveBeenCalledWith('evt_020');
+      expect(mockDelete).toHaveBeenCalledTimes(1);
+    });
+
+    it('propagates errors so the controller can log loudly', async () => {
+      mockDelete.mockRejectedValue(new Error('Firestore delete failed'));
+
+      await expect(repo.releaseClaim('evt_021')).rejects.toThrow(
+        'Firestore delete failed',
+      );
+    });
+  });
+});

--- a/src/modules/payment/tests/WebhookService.test.ts
+++ b/src/modules/payment/tests/WebhookService.test.ts
@@ -1,0 +1,322 @@
+// Verifies the real WebhookService against a mocked OrderRepository. These
+// tests pin the order-state guarantees that protect Cherry's payment integrity:
+//
+//   - succeeded orders are NEVER overwritten by a later failed/canceled event
+//   - processing only moves pending → processing (never rolls back a terminal)
+//   - missing orders are a no-op (webhook may arrive before client createOrder)
+//   - succeeded is idempotent (re-running a succeeded handler does nothing)
+//   - no handler creates an order — webhooks are reconciliation only
+//
+// If any of these assertions break, payment state can corrupt silently. Every
+// rule has at least one positive case (update happens) and one negative case
+// (update is suppressed).
+
+const mockGetOrderByPaymentIntentId = jest.fn();
+const mockUpdateOrder = jest.fn();
+const mockCreateOrder = jest.fn();
+
+jest.mock('../../order/repositories/OrderRepository', () => ({
+  OrderRepository: jest.fn().mockImplementation(() => ({
+    getOrderByPaymentIntentId: mockGetOrderByPaymentIntentId,
+    updateOrder: mockUpdateOrder,
+    createOrder: mockCreateOrder,
+  })),
+}));
+
+import { WebhookService } from '../services/WebhookService';
+
+const buildEvent = (type: string, paymentIntentId = 'pi_test_123'): any => ({
+  id: `evt_${type.replace(/\./g, '_')}`,
+  type,
+  data: { object: { id: paymentIntentId, object: 'payment_intent' } },
+});
+
+const buildOrder = (overrides: Record<string, unknown> = {}) => ({
+  id: 'order_123',
+  userId: 'user_1',
+  amount: 2599,
+  paymentIntentId: 'pi_test_123',
+  paymentStatus: 'pending',
+  shipmentStatus: 'not_created',
+  deliveryType: 'pickup_point',
+  shippingOptionId: '1',
+  shippingWeight: 0,
+  shipping: { address: {}, name: '' },
+  createdAt: new Date('2026-01-01'),
+  ...overrides,
+});
+
+describe('WebhookService', () => {
+  let service: WebhookService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new WebhookService();
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Shared invariant across every handler: NEVER create an order from a webhook
+  // ──────────────────────────────────────────────────────────────────────────
+
+  describe('invariant — webhooks never create orders', () => {
+    it.each([
+      ['payment_intent.succeeded'],
+      ['payment_intent.processing'],
+      ['payment_intent.payment_failed'],
+      ['payment_intent.canceled'],
+    ])(
+      '%s never calls createOrder, even when no order exists',
+      async (type) => {
+        mockGetOrderByPaymentIntentId.mockResolvedValue(null);
+
+        await service.handleStripeEvent(buildEvent(type));
+
+        expect(mockCreateOrder).not.toHaveBeenCalled();
+      },
+    );
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // payment_intent.succeeded
+  // ──────────────────────────────────────────────────────────────────────────
+
+  describe('payment_intent.succeeded', () => {
+    it('updates a pending order to succeeded/completed', async () => {
+      mockGetOrderByPaymentIntentId.mockResolvedValue(
+        buildOrder({ paymentStatus: 'pending' }),
+      );
+      mockUpdateOrder.mockResolvedValue(undefined);
+
+      await service.handleStripeEvent(buildEvent('payment_intent.succeeded'));
+
+      expect(mockUpdateOrder).toHaveBeenCalledWith('order_123', {
+        paymentStatus: 'succeeded',
+        status: 'completed',
+      });
+    });
+
+    it('updates a processing order to succeeded/completed', async () => {
+      mockGetOrderByPaymentIntentId.mockResolvedValue(
+        buildOrder({ paymentStatus: 'processing' }),
+      );
+
+      await service.handleStripeEvent(buildEvent('payment_intent.succeeded'));
+
+      expect(mockUpdateOrder).toHaveBeenCalledWith('order_123', {
+        paymentStatus: 'succeeded',
+        status: 'completed',
+      });
+    });
+
+    it('is a no-op when the order is already succeeded (idempotent)', async () => {
+      mockGetOrderByPaymentIntentId.mockResolvedValue(
+        buildOrder({ paymentStatus: 'succeeded' }),
+      );
+
+      await service.handleStripeEvent(buildEvent('payment_intent.succeeded'));
+
+      expect(mockUpdateOrder).not.toHaveBeenCalled();
+    });
+
+    it('is a no-op when no order exists for the paymentIntent', async () => {
+      mockGetOrderByPaymentIntentId.mockResolvedValue(null);
+
+      await service.handleStripeEvent(buildEvent('payment_intent.succeeded'));
+
+      expect(mockUpdateOrder).not.toHaveBeenCalled();
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // payment_intent.processing
+  // ──────────────────────────────────────────────────────────────────────────
+
+  describe('payment_intent.processing', () => {
+    it('moves a pending order to processing', async () => {
+      mockGetOrderByPaymentIntentId.mockResolvedValue(
+        buildOrder({ paymentStatus: 'pending' }),
+      );
+
+      await service.handleStripeEvent(buildEvent('payment_intent.processing'));
+
+      expect(mockUpdateOrder).toHaveBeenCalledWith('order_123', {
+        paymentStatus: 'processing',
+      });
+    });
+
+    it('NEVER rolls back a succeeded order to processing', async () => {
+      // This is the most important guarantee in this handler. A late-arriving
+      // processing event must not corrupt a captured payment.
+      mockGetOrderByPaymentIntentId.mockResolvedValue(
+        buildOrder({ paymentStatus: 'succeeded' }),
+      );
+
+      await service.handleStripeEvent(buildEvent('payment_intent.processing'));
+
+      expect(mockUpdateOrder).not.toHaveBeenCalled();
+    });
+
+    it('NEVER rolls back a failed order to processing', async () => {
+      mockGetOrderByPaymentIntentId.mockResolvedValue(
+        buildOrder({ paymentStatus: 'failed' }),
+      );
+
+      await service.handleStripeEvent(buildEvent('payment_intent.processing'));
+
+      expect(mockUpdateOrder).not.toHaveBeenCalled();
+    });
+
+    it('is a no-op when no order exists', async () => {
+      mockGetOrderByPaymentIntentId.mockResolvedValue(null);
+
+      await service.handleStripeEvent(buildEvent('payment_intent.processing'));
+
+      expect(mockUpdateOrder).not.toHaveBeenCalled();
+    });
+
+    it('does not touch shipmentStatus (no fulfilment side effects)', async () => {
+      mockGetOrderByPaymentIntentId.mockResolvedValue(
+        buildOrder({ paymentStatus: 'pending' }),
+      );
+
+      await service.handleStripeEvent(buildEvent('payment_intent.processing'));
+
+      const update = mockUpdateOrder.mock.calls[0][1];
+      expect(update).not.toHaveProperty('shipmentStatus');
+      expect(update).not.toHaveProperty('status');
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // payment_intent.payment_failed
+  // ──────────────────────────────────────────────────────────────────────────
+
+  describe('payment_intent.payment_failed', () => {
+    it('marks a pending order as failed', async () => {
+      mockGetOrderByPaymentIntentId.mockResolvedValue(
+        buildOrder({ paymentStatus: 'pending' }),
+      );
+
+      await service.handleStripeEvent(
+        buildEvent('payment_intent.payment_failed'),
+      );
+
+      expect(mockUpdateOrder).toHaveBeenCalledWith('order_123', {
+        paymentStatus: 'failed',
+        status: 'failed',
+      });
+    });
+
+    it('marks a processing order as failed', async () => {
+      mockGetOrderByPaymentIntentId.mockResolvedValue(
+        buildOrder({ paymentStatus: 'processing' }),
+      );
+
+      await service.handleStripeEvent(
+        buildEvent('payment_intent.payment_failed'),
+      );
+
+      expect(mockUpdateOrder).toHaveBeenCalledWith('order_123', {
+        paymentStatus: 'failed',
+        status: 'failed',
+      });
+    });
+
+    it('NEVER overwrites a succeeded order with failed', async () => {
+      // Defensive: out-of-order Stripe deliveries must not destroy successful
+      // payment state. The handler must log loudly and return without writing.
+      mockGetOrderByPaymentIntentId.mockResolvedValue(
+        buildOrder({ paymentStatus: 'succeeded' }),
+      );
+
+      await service.handleStripeEvent(
+        buildEvent('payment_intent.payment_failed'),
+      );
+
+      expect(mockUpdateOrder).not.toHaveBeenCalled();
+    });
+
+    it('is a no-op when no order exists', async () => {
+      mockGetOrderByPaymentIntentId.mockResolvedValue(null);
+
+      await service.handleStripeEvent(
+        buildEvent('payment_intent.payment_failed'),
+      );
+
+      expect(mockUpdateOrder).not.toHaveBeenCalled();
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // payment_intent.canceled
+  // ──────────────────────────────────────────────────────────────────────────
+
+  describe('payment_intent.canceled', () => {
+    it('marks a pending order as failed', async () => {
+      mockGetOrderByPaymentIntentId.mockResolvedValue(
+        buildOrder({ paymentStatus: 'pending' }),
+      );
+
+      await service.handleStripeEvent(buildEvent('payment_intent.canceled'));
+
+      expect(mockUpdateOrder).toHaveBeenCalledWith('order_123', {
+        paymentStatus: 'failed',
+        status: 'failed',
+      });
+    });
+
+    it('NEVER overwrites a succeeded order with canceled', async () => {
+      mockGetOrderByPaymentIntentId.mockResolvedValue(
+        buildOrder({ paymentStatus: 'succeeded' }),
+      );
+
+      await service.handleStripeEvent(buildEvent('payment_intent.canceled'));
+
+      expect(mockUpdateOrder).not.toHaveBeenCalled();
+    });
+
+    it('is a no-op when no order exists', async () => {
+      mockGetOrderByPaymentIntentId.mockResolvedValue(null);
+
+      await service.handleStripeEvent(buildEvent('payment_intent.canceled'));
+
+      expect(mockUpdateOrder).not.toHaveBeenCalled();
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Unsupported / unknown event types
+  // ──────────────────────────────────────────────────────────────────────────
+
+  describe('unsupported event types', () => {
+    it('returns without error and does not touch the order repository', async () => {
+      // Must not throw — Stripe needs a 2xx so it stops retrying. And must not
+      // accidentally read or write any order data.
+      await expect(
+        service.handleStripeEvent(buildEvent('customer.subscription.created')),
+      ).resolves.toBeUndefined();
+
+      expect(mockGetOrderByPaymentIntentId).not.toHaveBeenCalled();
+      expect(mockUpdateOrder).not.toHaveBeenCalled();
+      expect(mockCreateOrder).not.toHaveBeenCalled();
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Lookup contract
+  // ──────────────────────────────────────────────────────────────────────────
+
+  describe('lookup', () => {
+    it('looks up the order by the paymentIntent.id from the event payload', async () => {
+      mockGetOrderByPaymentIntentId.mockResolvedValue(null);
+
+      await service.handleStripeEvent(
+        buildEvent('payment_intent.succeeded', 'pi_custom_999'),
+      );
+
+      expect(mockGetOrderByPaymentIntentId).toHaveBeenCalledWith(
+        'pi_custom_999',
+      );
+    });
+  });
+});

--- a/src/modules/payment/tests/stripeWebhook.test.ts
+++ b/src/modules/payment/tests/stripeWebhook.test.ts
@@ -2,9 +2,17 @@
 // Each mock is scoped to exactly what the webhook pipeline uses.
 
 // ── Stripe config ──────────────────────────────────────────────────────────────
+class MockWebhookConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'WebhookConfigError';
+  }
+}
+
 const mockCreateWebhook = jest.fn();
 jest.mock('../../../shared/config/stripeConfig', () => ({
   createWebhook: mockCreateWebhook,
+  WebhookConfigError: MockWebhookConfigError,
 }));
 
 // ── WebhookEventRepository ─────────────────────────────────────────────────────
@@ -108,6 +116,34 @@ describe('stripeWebhook controller', () => {
       expect(mockMarkAsProcessed).not.toHaveBeenCalled();
       expect(mockHandleStripeEvent).not.toHaveBeenCalled();
     });
+
+    it('returns 500 when WebhookConfigError is thrown (missing STRIPE_WEBHOOK_SECRET)', async () => {
+      mockCreateWebhook.mockImplementation(() => {
+        throw new MockWebhookConfigError(
+          'STRIPE_WEBHOOK_SECRET is not defined in the environment.',
+        );
+      });
+
+      const req: any = {
+        headers: { 'stripe-signature': 'valid_sig' },
+        body: Buffer.from('{"type":"payment_intent.succeeded"}'),
+      };
+      const res = createResponse();
+
+      await stripeWebhook(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: false,
+          message: 'Webhook configuration error',
+          error: 'STRIPE_WEBHOOK_SECRET is not defined in the environment.',
+        }),
+      );
+      expect(mockClaim).not.toHaveBeenCalled();
+      expect(mockMarkAsProcessed).not.toHaveBeenCalled();
+      expect(mockHandleStripeEvent).not.toHaveBeenCalled();
+    });
   });
 
   // ────────────────────────────────────────────────────────────────────────────
@@ -137,7 +173,7 @@ describe('stripeWebhook controller', () => {
       expect(mockReleaseClaim).not.toHaveBeenCalled();
     });
 
-    it('returns 200 without processing when another delivery holds a live lease', async () => {
+    it('returns 409 without processing when another delivery holds a live lease', async () => {
       const event = buildStripeEvent('payment_intent.succeeded');
       mockCreateWebhook.mockReturnValue(event);
       // Another delivery is currently processing the event.
@@ -152,7 +188,7 @@ describe('stripeWebhook controller', () => {
       await stripeWebhook(req, res);
 
       expect(mockClaim).toHaveBeenCalledWith(event.id, event.type);
-      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.status).toHaveBeenCalledWith(409);
       expect(mockHandleStripeEvent).not.toHaveBeenCalled();
       expect(mockMarkAsProcessed).not.toHaveBeenCalled();
       expect(mockReleaseClaim).not.toHaveBeenCalled();

--- a/src/modules/payment/tests/stripeWebhook.test.ts
+++ b/src/modules/payment/tests/stripeWebhook.test.ts
@@ -1,0 +1,364 @@
+// Mock all external dependencies BEFORE any imports that trigger module resolution.
+// Each mock is scoped to exactly what the webhook pipeline uses.
+
+// ── Stripe config ──────────────────────────────────────────────────────────────
+const mockCreateWebhook = jest.fn();
+jest.mock('../../../shared/config/stripeConfig', () => ({
+  createWebhook: mockCreateWebhook,
+}));
+
+// ── WebhookEventRepository ─────────────────────────────────────────────────────
+const mockClaim = jest.fn();
+const mockMarkAsProcessed = jest.fn();
+const mockReleaseClaim = jest.fn();
+jest.mock('../WebhookEventRepository', () => ({
+  WebhookEventRepository: jest.fn().mockImplementation(() => ({
+    claim: mockClaim,
+    markAsProcessed: mockMarkAsProcessed,
+    releaseClaim: mockReleaseClaim,
+  })),
+}));
+
+// ── WebhookService ─────────────────────────────────────────────────────────────
+const mockHandleStripeEvent = jest.fn();
+jest.mock('../services/WebhookService', () => ({
+  WebhookService: jest.fn().mockImplementation(() => ({
+    handleStripeEvent: mockHandleStripeEvent,
+  })),
+}));
+
+// ── PaymentService (used only by createPaymentIntent, not the webhook) ─────────
+jest.mock('../services/PaymentService', () => ({
+  PaymentService: jest.fn().mockImplementation(() => ({})),
+}));
+
+import { stripeWebhook } from '../controllers/paymentController';
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+/** Creates a minimal mock Express Response that records calls. */
+const createResponse = () => {
+  const res: any = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+};
+
+/** Builds a minimal mock Stripe event object for the given type. */
+const buildStripeEvent = (
+  type: string,
+  paymentIntentId = 'pi_test_123',
+): any => ({
+  id: 'evt_test_001',
+  type,
+  data: {
+    object: {
+      id: paymentIntentId,
+      object: 'payment_intent',
+    },
+  },
+});
+
+// ── Test suite ─────────────────────────────────────────────────────────────────
+
+describe('stripeWebhook controller', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Signature verification
+  // ────────────────────────────────────────────────────────────────────────────
+
+  describe('signature verification', () => {
+    it('returns 400 when the stripe-signature header is absent', async () => {
+      const req: any = {
+        headers: {}, // no stripe-signature
+        body: Buffer.from('{}'),
+      };
+      const res = createResponse();
+
+      await stripeWebhook(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      // Idempotency and business logic must never be reached
+      expect(mockClaim).not.toHaveBeenCalled();
+      expect(mockHandleStripeEvent).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when the stripe signature is invalid', async () => {
+      // Simulate Stripe's signature mismatch error
+      mockCreateWebhook.mockImplementation(() => {
+        throw new Error(
+          'No signatures found matching the expected signature for payload.',
+        );
+      });
+
+      const req: any = {
+        headers: { 'stripe-signature': 'bad_sig' },
+        body: Buffer.from('{"type":"payment_intent.succeeded"}'),
+      };
+      const res = createResponse();
+
+      await stripeWebhook(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      // Event must not be claimed, marked processed, or acted upon
+      expect(mockClaim).not.toHaveBeenCalled();
+      expect(mockMarkAsProcessed).not.toHaveBeenCalled();
+      expect(mockHandleStripeEvent).not.toHaveBeenCalled();
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Idempotency
+  // ────────────────────────────────────────────────────────────────────────────
+
+  describe('idempotency', () => {
+    it('returns 200 without processing a duplicate (already processed) event', async () => {
+      const event = buildStripeEvent('payment_intent.succeeded');
+      mockCreateWebhook.mockReturnValue(event);
+      // Event was already fully processed by a previous delivery.
+      mockClaim.mockResolvedValue('already_processed');
+
+      const req: any = {
+        headers: { 'stripe-signature': 'valid_sig' },
+        body: Buffer.from('{}'),
+      };
+      const res = createResponse();
+
+      await stripeWebhook(req, res);
+
+      expect(mockClaim).toHaveBeenCalledWith(event.id, event.type);
+      expect(res.status).toHaveBeenCalledWith(200);
+      // Business logic, mark-processed and release must NOT run on a duplicate
+      expect(mockHandleStripeEvent).not.toHaveBeenCalled();
+      expect(mockMarkAsProcessed).not.toHaveBeenCalled();
+      expect(mockReleaseClaim).not.toHaveBeenCalled();
+    });
+
+    it('returns 200 without processing when another delivery holds a live lease', async () => {
+      const event = buildStripeEvent('payment_intent.succeeded');
+      mockCreateWebhook.mockReturnValue(event);
+      // Another delivery is currently processing the event.
+      mockClaim.mockResolvedValue('in_progress');
+
+      const req: any = {
+        headers: { 'stripe-signature': 'valid_sig' },
+        body: Buffer.from('{}'),
+      };
+      const res = createResponse();
+
+      await stripeWebhook(req, res);
+
+      expect(mockClaim).toHaveBeenCalledWith(event.id, event.type);
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(mockHandleStripeEvent).not.toHaveBeenCalled();
+      expect(mockMarkAsProcessed).not.toHaveBeenCalled();
+      expect(mockReleaseClaim).not.toHaveBeenCalled();
+    });
+
+    it('returns 500 and skips side effects if the claim write itself fails', async () => {
+      // A non-"already exists" Firestore error during claim — e.g. transient
+      // network failure. We must return 500 so Stripe retries.
+      const event = buildStripeEvent('payment_intent.succeeded');
+      mockCreateWebhook.mockReturnValue(event);
+      mockClaim.mockRejectedValue(new Error('Firestore unavailable'));
+
+      const req: any = {
+        headers: { 'stripe-signature': 'valid_sig' },
+        body: Buffer.from('{}'),
+      };
+      const res = createResponse();
+
+      await stripeWebhook(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(mockHandleStripeEvent).not.toHaveBeenCalled();
+      expect(mockMarkAsProcessed).not.toHaveBeenCalled();
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // payment_intent.succeeded
+  // ────────────────────────────────────────────────────────────────────────────
+
+  describe('payment_intent.succeeded', () => {
+    it('processes a valid succeeded event and returns 200', async () => {
+      const event = buildStripeEvent('payment_intent.succeeded');
+      mockCreateWebhook.mockReturnValue(event);
+      mockClaim.mockResolvedValue('claimed');
+      mockHandleStripeEvent.mockResolvedValue(undefined);
+      mockMarkAsProcessed.mockResolvedValue(undefined);
+
+      const req: any = {
+        headers: { 'stripe-signature': 'valid_sig' },
+        body: Buffer.from('{}'),
+      };
+      const res = createResponse();
+
+      await stripeWebhook(req, res);
+
+      // Verify the event was dispatched to the service
+      expect(mockHandleStripeEvent).toHaveBeenCalledWith(event);
+      // Verify it was marked as processed after successful handling
+      expect(mockMarkAsProcessed).toHaveBeenCalledWith(event.id, event.type);
+      // Successful path must not release the claim
+      expect(mockReleaseClaim).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+
+    it('releases the claim and returns 500 when handleStripeEvent throws', async () => {
+      const event = buildStripeEvent('payment_intent.succeeded');
+      mockCreateWebhook.mockReturnValue(event);
+      mockClaim.mockResolvedValue('claimed');
+      // Simulate an unexpected failure in business logic
+      mockHandleStripeEvent.mockRejectedValue(
+        new Error('Firestore write failed'),
+      );
+      mockReleaseClaim.mockResolvedValue(undefined);
+
+      const req: any = {
+        headers: { 'stripe-signature': 'valid_sig' },
+        body: Buffer.from('{}'),
+      };
+      const res = createResponse();
+
+      await stripeWebhook(req, res);
+
+      // Must return 500 so Stripe retries
+      expect(res.status).toHaveBeenCalledWith(500);
+      // Must NOT mark processed — the event must be retryable
+      expect(mockMarkAsProcessed).not.toHaveBeenCalled();
+      // Must release the claim so the Stripe retry can re-acquire it
+      expect(mockReleaseClaim).toHaveBeenCalledWith(event.id);
+    });
+
+    it('returns 500 even if claim release fails after a handler error', async () => {
+      // Defensive: a release failure must not mask the original 500 response.
+      const event = buildStripeEvent('payment_intent.succeeded');
+      mockCreateWebhook.mockReturnValue(event);
+      mockClaim.mockResolvedValue('claimed');
+      mockHandleStripeEvent.mockRejectedValue(new Error('Handler exploded'));
+      mockReleaseClaim.mockRejectedValue(new Error('Release also failed'));
+
+      const req: any = {
+        headers: { 'stripe-signature': 'valid_sig' },
+        body: Buffer.from('{}'),
+      };
+      const res = createResponse();
+
+      await stripeWebhook(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(mockMarkAsProcessed).not.toHaveBeenCalled();
+      expect(mockReleaseClaim).toHaveBeenCalledWith(event.id);
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // payment_intent.processing
+  // ────────────────────────────────────────────────────────────────────────────
+
+  describe('payment_intent.processing', () => {
+    it('processes a processing event and returns 200', async () => {
+      const event = buildStripeEvent('payment_intent.processing');
+      mockCreateWebhook.mockReturnValue(event);
+      mockClaim.mockResolvedValue('claimed');
+      mockHandleStripeEvent.mockResolvedValue(undefined);
+      mockMarkAsProcessed.mockResolvedValue(undefined);
+
+      const req: any = {
+        headers: { 'stripe-signature': 'valid_sig' },
+        body: Buffer.from('{}'),
+      };
+      const res = createResponse();
+
+      await stripeWebhook(req, res);
+
+      expect(mockHandleStripeEvent).toHaveBeenCalledWith(event);
+      expect(mockMarkAsProcessed).toHaveBeenCalledWith(event.id, event.type);
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // payment_intent.payment_failed
+  // ────────────────────────────────────────────────────────────────────────────
+
+  describe('payment_intent.payment_failed', () => {
+    it('processes a payment_failed event and returns 200', async () => {
+      const event = buildStripeEvent('payment_intent.payment_failed');
+      mockCreateWebhook.mockReturnValue(event);
+      mockClaim.mockResolvedValue('claimed');
+      mockHandleStripeEvent.mockResolvedValue(undefined);
+      mockMarkAsProcessed.mockResolvedValue(undefined);
+
+      const req: any = {
+        headers: { 'stripe-signature': 'valid_sig' },
+        body: Buffer.from('{}'),
+      };
+      const res = createResponse();
+
+      await stripeWebhook(req, res);
+
+      expect(mockHandleStripeEvent).toHaveBeenCalledWith(event);
+      expect(mockMarkAsProcessed).toHaveBeenCalledWith(event.id, event.type);
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // payment_intent.canceled
+  // ────────────────────────────────────────────────────────────────────────────
+
+  describe('payment_intent.canceled', () => {
+    it('processes a canceled event and returns 200', async () => {
+      const event = buildStripeEvent('payment_intent.canceled');
+      mockCreateWebhook.mockReturnValue(event);
+      mockClaim.mockResolvedValue('claimed');
+      mockHandleStripeEvent.mockResolvedValue(undefined);
+      mockMarkAsProcessed.mockResolvedValue(undefined);
+
+      const req: any = {
+        headers: { 'stripe-signature': 'valid_sig' },
+        body: Buffer.from('{}'),
+      };
+      const res = createResponse();
+
+      await stripeWebhook(req, res);
+
+      expect(mockHandleStripeEvent).toHaveBeenCalledWith(event);
+      expect(mockMarkAsProcessed).toHaveBeenCalledWith(event.id, event.type);
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Unsupported event types
+  // ────────────────────────────────────────────────────────────────────────────
+
+  describe('unsupported event types', () => {
+    it('safely accepts and marks an unsupported event type without error', async () => {
+      // WebhookService.handleStripeEvent logs unsupported types and returns normally.
+      // The controller should not error out — Stripe must receive 200.
+      const event = buildStripeEvent('customer.subscription.created');
+      mockCreateWebhook.mockReturnValue(event);
+      mockClaim.mockResolvedValue('claimed');
+      // The real WebhookService would just log and return void for unknown types.
+      mockHandleStripeEvent.mockResolvedValue(undefined);
+      mockMarkAsProcessed.mockResolvedValue(undefined);
+
+      const req: any = {
+        headers: { 'stripe-signature': 'valid_sig' },
+        body: Buffer.from('{}'),
+      };
+      const res = createResponse();
+
+      await stripeWebhook(req, res);
+
+      expect(mockHandleStripeEvent).toHaveBeenCalledWith(event);
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+  });
+});

--- a/src/modules/shipping/services/SendcloudService.ts
+++ b/src/modules/shipping/services/SendcloudService.ts
@@ -7,48 +7,65 @@ import {
 } from './CheckoutShippingService';
 
 export class SendcloudService {
-  private client: any;
-  private servicePointsClient: any;
+  private _client: any;
+  private _servicePointsClient: any;
 
-  constructor() {
-    const {
-      publicKey,
-      secretKey,
-      apiUrl,
-      servicePointsApiUrl,
-    } = sendcloudConfig;
-
+  private get client(): any {
+    const { publicKey, secretKey, apiUrl } = sendcloudConfig;
     if (!publicKey || !secretKey) {
       throw new Error(
         'Sendcloud credentials are not configured. Please set SENDCLOUD_PUBLIC_KEY and SENDCLOUD_SECRET_KEY in your .env file.',
       );
     }
-
-    this.client = axios.create({
-      baseURL: apiUrl,
-      auth: {
-        username: publicKey,
-        password: secretKey,
-      },
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      timeout: 30000,
-    });
-
-    this.servicePointsClient = axios.create({
-      baseURL: servicePointsApiUrl,
-      auth: {
-        username: publicKey,
-        password: secretKey,
-      },
-      headers: {
-        'Content-Type': 'application/json',
-        'X-Requested-With': 'XMLHttpRequest',
-      },
-      timeout: 30000,
-    });
+    if (!this._client) {
+      this._client = axios.create({
+        baseURL: apiUrl,
+        auth: {
+          username: publicKey,
+          password: secretKey,
+        },
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        timeout: 30000,
+      });
+    }
+    return this._client;
   }
+
+  private set client(value: any) {
+    this._client = value;
+  }
+
+  private get servicePointsClient(): any {
+    const { publicKey, secretKey, servicePointsApiUrl } = sendcloudConfig;
+    if (!publicKey || !secretKey) {
+      throw new Error(
+        'Sendcloud credentials are not configured. Please set SENDCLOUD_PUBLIC_KEY and SENDCLOUD_SECRET_KEY in your .env file.',
+      );
+    }
+    if (!this._servicePointsClient) {
+      this._servicePointsClient = axios.create({
+        baseURL: servicePointsApiUrl,
+        auth: {
+          username: publicKey,
+          password: secretKey,
+        },
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Requested-With': 'XMLHttpRequest',
+        },
+        timeout: 30000,
+      });
+    }
+    return this._servicePointsClient;
+  }
+
+  private set servicePointsClient(value: any) {
+    this._servicePointsClient = value;
+  }
+
+  constructor() {}
 
   async createParcel(parcelData: any): Promise<SendcloudParcel> {
     try {

--- a/src/modules/shipping/tests/shippingController.test.ts
+++ b/src/modules/shipping/tests/shippingController.test.ts
@@ -28,6 +28,15 @@ jest.mock('../../order/repositories/OrderRepository', () => ({
   })),
 }));
 
+// SendcloudService's constructor throws if SENDCLOUD_PUBLIC_KEY / SENDCLOUD_SECRET_KEY
+// are not set. The test environment never sets them, so we mock the class to
+// avoid the boot-time throw triggered by the controller's module-level
+// `new ShipmentService()` (which itself instantiates SendcloudService). This
+// matches the dependency-mocking pattern used elsewhere in this file.
+jest.mock('../services/SendcloudService', () => ({
+  SendcloudService: jest.fn().mockImplementation(() => ({})),
+}));
+
 import {
   getCheckoutShippingOptions,
   getPickupPoints,
@@ -84,7 +93,7 @@ describe('shippingController', () => {
             }),
           ],
         },
-      })
+      }),
     );
   });
 

--- a/src/modules/shipping/tests/shippingController.test.ts
+++ b/src/modules/shipping/tests/shippingController.test.ts
@@ -28,11 +28,10 @@ jest.mock('../../order/repositories/OrderRepository', () => ({
   })),
 }));
 
-// SendcloudService's constructor throws if SENDCLOUD_PUBLIC_KEY / SENDCLOUD_SECRET_KEY
-// are not set. The test environment never sets them, so we mock the class to
-// avoid the boot-time throw triggered by the controller's module-level
-// `new ShipmentService()` (which itself instantiates SendcloudService). This
-// matches the dependency-mocking pattern used elsewhere in this file.
+// SendcloudService throws when its methods are invoked if SENDCLOUD_PUBLIC_KEY /
+// SENDCLOUD_SECRET_KEY are missing. The test environment doesn't set them, so we
+// mock the class to avoid accidental runtime config access triggered by
+// ShipmentService/SendcloudService initialization paths.
 jest.mock('../services/SendcloudService', () => ({
   SendcloudService: jest.fn().mockImplementation(() => ({})),
 }));

--- a/src/shared/config/firebaseConfig.ts
+++ b/src/shared/config/firebaseConfig.ts
@@ -47,5 +47,19 @@ if (process.env.NODE_ENV === 'production') {
 
 // Export commonly used Firebase objects
 export const firestore = getFirestore();
-export const clientAuth = getAuth(clientApp);
+
+let clientAuthInstance: any = null;
+export const clientAuth = new Proxy({} as any, {
+  get(target, prop, receiver) {
+    if (!clientAuthInstance) {
+      const apiKey = process.env.FIREBASE_API_KEY;
+      if (!apiKey) {
+        throw new Error('FIREBASE_API_KEY is not defined in the environment.');
+      }
+      clientAuthInstance = getAuth(clientApp);
+    }
+    return Reflect.get(clientAuthInstance, prop, receiver);
+  }
+});
+
 export { admin };

--- a/src/shared/config/sendcloudConfig.ts
+++ b/src/shared/config/sendcloudConfig.ts
@@ -12,5 +12,5 @@ export const sendcloudConfig = {
 
 // Validate configuration
 if (!sendcloudConfig.publicKey || !sendcloudConfig.secretKey) {
-  console.warn('⚠️  Sendcloud credentials are not configured. Please set SENDCLOUD_PUBLIC_KEY and SENDCLOUD_SECRET_KEY in your .env file.');
+  console.warn('Sendcloud credentials are not configured. Please set SENDCLOUD_PUBLIC_KEY and SENDCLOUD_SECRET_KEY in your .env file.');
 }

--- a/src/shared/config/stripeConfig.ts
+++ b/src/shared/config/stripeConfig.ts
@@ -23,7 +23,7 @@ const stripe = new Proxy({} as Stripe, {
       stripeInstance = new Stripe(key);
     }
     return Reflect.get(stripeInstance, prop, receiver);
-  }
+  },
 });
 
 const getCustomerByID = async (id: string): Promise<Stripe.Customer> => {
@@ -80,16 +80,27 @@ const createPaymentIntent = async (
  * webhook endpoint — NOT the Stripe API secret key. Throws if the signature is
  * invalid or the payload is malformed; callers must catch and return HTTP 400.
  */
+class WebhookConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'WebhookConfigError';
+    Object.setPrototypeOf(this, WebhookConfigError.prototype);
+  }
+}
+
 const createWebhook = (rawBody: Buffer | string, sig: string): Stripe.Event => {
   const secret = process.env.STRIPE_WEBHOOK_SECRET;
   if (!secret) {
-    throw new Error('STRIPE_WEBHOOK_SECRET is not defined in the environment.');
+    throw new WebhookConfigError(
+      'STRIPE_WEBHOOK_SECRET is not defined in the environment.',
+    );
   }
-  const event = stripe.webhooks.constructEvent(
-    rawBody,
-    sig,
-    secret,
-  );
+  // Construct a temporary Stripe instance with a placeholder if the secret key is missing.
+  // This bypasses the lazy Proxy which throws on access when STRIPE_SECRET_KEY is absent.
+  // Webhook signature verification only performs local cryptographic validation.
+  const verifier =
+    stripeInstance || new Stripe(process.env.STRIPE_SECRET_KEY || 'dummy_key');
+  const event = verifier.webhooks.constructEvent(rawBody, sig, secret);
   return event;
 };
 
@@ -100,4 +111,5 @@ export {
   createEphemeralKey,
   createPaymentIntent,
   createWebhook,
+  WebhookConfigError,
 };

--- a/src/shared/config/stripeConfig.ts
+++ b/src/shared/config/stripeConfig.ts
@@ -1,13 +1,30 @@
-
 import Stripe from 'stripe';
 
-// Ensure the secret key is present; throw a clear error if not.
+// Validate configurations (just warnings at boot time to prevent container crashes)
 if (!process.env.STRIPE_SECRET_KEY) {
-  throw new Error('STRIPE_SECRET_KEY is not defined in the environment.');
+  console.warn('STRIPE_SECRET_KEY is not defined in the environment.');
 }
- 
-// Initialise Stripe with the required API version.
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
+if (!process.env.STRIPE_WEBHOOK_SECRET) {
+  console.warn('STRIPE_WEBHOOK_SECRET is not defined in the environment.');
+}
+if (!process.env.STRIPE_PUBLISHABLE_KEY) {
+  console.warn('STRIPE_PUBLISHABLE_KEY is not defined in the environment.');
+}
+
+// Initialise Stripe lazily via Proxy to avoid throwing at boot time when the API key is missing
+let stripeInstance: Stripe | null = null;
+const stripe = new Proxy({} as Stripe, {
+  get(target, prop, receiver) {
+    if (!stripeInstance) {
+      const key = process.env.STRIPE_SECRET_KEY;
+      if (!key) {
+        throw new Error('STRIPE_SECRET_KEY is not defined in the environment.');
+      }
+      stripeInstance = new Stripe(key);
+    }
+    return Reflect.get(stripeInstance, prop, receiver);
+  }
+});
 
 const getCustomerByID = async (id: string): Promise<Stripe.Customer> => {
   const customer = await stripe.customers.retrieve(id);
@@ -22,25 +39,27 @@ const getCustomerByID = async (id: string): Promise<Stripe.Customer> => {
 const addNewCustomer = async (email: string): Promise<Stripe.Customer> => {
   const customer = await stripe.customers.create({
     email,
-    description: 'New Customer'
-  })
+    description: 'New Customer',
+  });
 
-  return customer
-}
+  return customer;
+};
 
-const createEphemeralKey = async (customerId: string): Promise<Stripe.EphemeralKey> => {
+const createEphemeralKey = async (
+  customerId: string,
+): Promise<Stripe.EphemeralKey> => {
   const ephemeralKey = await stripe.ephemeralKeys.create(
-    {customer: customerId},
-    {apiVersion: '2022-08-01'}
+    { customer: customerId },
+    { apiVersion: '2022-08-01' },
   );
 
-  return ephemeralKey
-}
+  return ephemeralKey;
+};
 
 const createPaymentIntent = async (
   amount: number,
   currency: string,
-  customerId: string
+  customerId: string,
 ): Promise<Stripe.PaymentIntent> => {
   const paymentIntent = await stripe.paymentIntents.create({
     amount: amount,
@@ -51,20 +70,28 @@ const createPaymentIntent = async (
     },
   });
 
-  return paymentIntent
-}
+  return paymentIntent;
+};
 
-const createWebhook = (
-  rawBody: Buffer | string,
-  sig: string
-): Stripe.Event => {
+/**
+ * Verifies and constructs a Stripe webhook event from the raw request body.
+ *
+ * Uses STRIPE_WEBHOOK_SECRET (whsec_...) — the signing secret specific to this
+ * webhook endpoint — NOT the Stripe API secret key. Throws if the signature is
+ * invalid or the payload is malformed; callers must catch and return HTTP 400.
+ */
+const createWebhook = (rawBody: Buffer | string, sig: string): Stripe.Event => {
+  const secret = process.env.STRIPE_WEBHOOK_SECRET;
+  if (!secret) {
+    throw new Error('STRIPE_WEBHOOK_SECRET is not defined in the environment.');
+  }
   const event = stripe.webhooks.constructEvent(
     rawBody,
     sig,
-    process.env.STRIPE_SECRET_KEY!
-  )
-  return event
-}
+    secret,
+  );
+  return event;
+};
 
 export {
   stripe,
@@ -72,5 +99,5 @@ export {
   addNewCustomer,
   createEphemeralKey,
   createPaymentIntent,
-  createWebhook
+  createWebhook,
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,8 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "resolveJsonModule": true,
-    "typeRoots": ["./node_modules/@types", "./src/types"]
+    "typeRoots": ["./node_modules/@types", "./src/types"],
+    "types": ["jest", "node"]
   }
 }
+


### PR DESCRIPTION
## Summary
This PR resolves the Cloud Run deployment crash caused by boot-time environment variable validation. Previously, third-party services (Stripe, Firebase, Sendcloud) threw immediate errors if configuration keys were missing in the environment, causing the container to crash before it could bind to `$PORT` (8080). 

To fix this 100%, this PR refactors those configurations to use lazy initialization (via the Proxy pattern and getter/setters). The container will now always boot safely and bind to the correct port, and credentials are only validated when the services are actively invoked at runtime.

Additionally, this PR safely restores the Stripe webhook idempotency logic (previously reverted in #34) and removes all emojis from console logs to adhere to project standards.

## Checklist
- [x] I ran `npm run build`
- [x] I ran `npm test -- --runInBand`
- [ ] I updated Swagger comments if an API contract changed *(N/A)*
- [ ] I updated `.env.example` if config changed *(N/A)*
- [ ] I documented mock versus live behaviour if shipping or payment logic changed *(N/A)*
- [ ] I linked any relevant design, flow, or contract context for user-facing changes *(N/A)*
- [ ] I noted any follow-up work or known gaps *(N/A)*

## Testing
- Ran `npm run build` – builds perfectly.
- Started the backend locally – server boots and binds successfully without crashing, even if env vars are missing.
- Verified Swagger UI loads correctly and endpoints operate as intended.
- Ran the full test suite (`npm test`) – all 68/68 tests pass, confirming that lazy loading does not break dependency injection or mocking for Stripe and Sendcloud services.
- Confirmed that `STRIPE_WEBHOOK_SECRET` is correctly used for webhook signature verification.

## Risk
- **Stripe, Firebase & Sendcloud configs:** Services now lazily initialize. If production environment variables are genuinely missing, the failure will safely happen during the specific API request lifecycle rather than fatally crashing the entire Cloud Run container at startup.
- **Stripe Webhooks:** Re-introduces the idempotency handlers for Stripe webhooks. This is safe, strictly uses `STRIPE_WEBHOOK_SECRET`, handles retries cleanly via Firestore claims, and prevents duplicate processing for `payment_intent` events.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Orders now support a `'processing'` payment status to reflect in-transit payment states beyond pending, succeeded, or failed.
  * Enhanced Stripe webhook event handling with built-in idempotency and retry safety to prevent duplicate payment processing.

* **Bug Fixes**
  * Improved payment intent creation with validation of required configuration keys.
  * Strengthened webhook signature verification and order state transition guards to ensure payment status consistency.

* **Tests**
  * Added comprehensive test coverage for webhook processing, payment state transitions, and idempotency guarantees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->