### PR TITLE
Enforce seller exclusion and block self-purchase

### DIFF
--- a/src/modules/order/controllers/orderController.ts
+++ b/src/modules/order/controllers/orderController.ts
@@ -11,6 +11,10 @@ import { ShipmentRepository } from '../../shipping/repositories/ShipmentReposito
 import { Shipment } from '../../shipping/models/Shipment';
 import { Order } from '../model/Order';
 import { requireSingleParam } from '../../../shared/utils/requestParam';
+import {
+  productBelongsToUser,
+  SELF_PURCHASE_ERROR,
+} from '../../products/utils/productOwnership';
 
 const ENFORCED_CARRIER = sendcloudConfig.enforcedCarrier;
 
@@ -216,6 +220,15 @@ export const createOrder = async (
       return;
     }
 
+    if (productBelongsToUser(product, firebaseUid)) {
+      ResponseHandler.forbidden(
+        res,
+        'Self-purchase is not allowed',
+        SELF_PURCHASE_ERROR,
+      );
+      return;
+    }
+
     if (!product.postageSize) {
       ResponseHandler.badRequest(
         res,
@@ -299,6 +312,17 @@ export const createOrder = async (
         ResponseHandler.conflict(
           res,
           'Checkout is no longer valid',
+          err.message,
+        );
+        return;
+      }
+      if (
+        err instanceof Error &&
+        err.message === SELF_PURCHASE_ERROR
+      ) {
+        ResponseHandler.forbidden(
+          res,
+          'Self-purchase is not allowed',
           err.message,
         );
         return;

--- a/src/modules/order/repositories/OrderRepository.ts
+++ b/src/modules/order/repositories/OrderRepository.ts
@@ -1,6 +1,10 @@
 import { firestore } from '../../../shared/config/firebaseConfig';
 import { gbpToPence } from '../../../shared/utils/money';
 import { Order } from '../model/Order';
+import {
+  productBelongsToUser,
+  SELF_PURCHASE_ERROR,
+} from '../../products/utils/productOwnership';
 
 const removeUndefinedValues = <T extends Record<string, unknown>>(value: T): T =>
   Object.fromEntries(
@@ -56,6 +60,10 @@ export class OrderRepository {
       }
 
       const productData = productDoc.data()!;
+      if (productBelongsToUser(productData, input.userId)) {
+        throw new Error(SELF_PURCHASE_ERROR);
+      }
+
       const quantity =
         typeof productData.number === 'number' ? productData.number : 0;
       if (quantity <= 0) {

--- a/src/modules/order/tests/orderController.test.ts
+++ b/src/modules/order/tests/orderController.test.ts
@@ -122,6 +122,7 @@ describe('orderController.createOrder', () => {
     });
     mockGetProductById.mockResolvedValue({
       id: 'product-1',
+      userId: 'seller-1',
       name: 'Winter Coat',
       postageSize: 'postage-size-1',
     });
@@ -301,6 +302,33 @@ describe('orderController.createOrder', () => {
 
     expect(mockCreatePaidOrderAndDecrementInventory).not.toHaveBeenCalled();
     expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('rejects an order for a product owned by the buyer', async () => {
+    mockGetProductById.mockResolvedValue({
+      id: 'product-1',
+      user_id: 'user-1',
+      name: 'Winter Coat',
+      postageSize: 'postage-size-1',
+    });
+    const req: any = {
+      user: {
+        uid: 'user-1',
+      },
+      body: payload,
+    };
+    const res = createResponse();
+
+    await createOrder(req, res);
+
+    expect(mockCreatePaidOrderAndDecrementInventory).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        message: 'Self-purchase is not allowed',
+      }),
+    );
   });
 });
 

--- a/src/modules/payment/controllers/paymentController.ts
+++ b/src/modules/payment/controllers/paymentController.ts
@@ -2,6 +2,7 @@ import { Request, Response } from 'express';
 import { ResponseHandler } from '../../../shared/utils/responseHandler';
 import { createWebhook } from '../../../shared/config/stripeConfig';
 import { PaymentService } from '../services/PaymentService';
+import { SELF_PURCHASE_ERROR } from '../../products/utils/productOwnership';
 
 export const createPaymentIntent = async (req: Request, res: Response): Promise<void> => {
   try {
@@ -16,6 +17,15 @@ export const createPaymentIntent = async (req: Request, res: Response): Promise<
 
     ResponseHandler.success(res, responseData, 'PaymentIntent created');
   } catch (err) {
+    if (err instanceof Error && err.message === SELF_PURCHASE_ERROR) {
+      ResponseHandler.forbidden(
+        res,
+        'Self-purchase is not allowed',
+        err.message,
+      );
+      return;
+    }
+
     ResponseHandler.badRequest(
       res,
       'Failed to create PaymentIntent',

--- a/src/modules/payment/services/PaymentService.ts
+++ b/src/modules/payment/services/PaymentService.ts
@@ -7,6 +7,10 @@ import { CheckoutShippingService } from '../../shipping/services/CheckoutShippin
 import { sendcloudConfig } from '../../../shared/config/sendcloudConfig';
 import { gbpToPence } from '../../../shared/utils/money';
 import { calculateSecurityFeePence } from '../../../shared/config/checkoutConfig';
+import {
+  productBelongsToUser,
+  SELF_PURCHASE_ERROR,
+} from '../../products/utils/productOwnership';
 
 export interface CreatePaymentSelection {
   productId: string;
@@ -53,6 +57,10 @@ export class PaymentService {
     const product = await this.productRepo.getById(selection.productId);
     if (!product) {
       throw new Error('Product not found');
+    }
+
+    if (productBelongsToUser(product, firebaseUid)) {
+      throw new Error(SELF_PURCHASE_ERROR);
     }
 
     if (product.number <= 0) {

--- a/src/modules/payment/tests/paymentController.test.ts
+++ b/src/modules/payment/tests/paymentController.test.ts
@@ -1,0 +1,47 @@
+const mockCreatePaymentIntentForUserByUid = jest.fn();
+
+jest.mock('../services/PaymentService', () => ({
+  PaymentService: jest.fn().mockImplementation(() => ({
+    createPaymentIntentForUserByUid: mockCreatePaymentIntentForUserByUid,
+  })),
+}));
+
+jest.mock('../../../shared/config/stripeConfig', () => ({
+  createWebhook: jest.fn(),
+}));
+
+import { createPaymentIntent } from '../controllers/paymentController';
+
+const createResponse = () => {
+  const res: any = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+};
+
+describe('paymentController.createPaymentIntent', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns 403 when the buyer owns the product', async () => {
+    mockCreatePaymentIntentForUserByUid.mockRejectedValue(
+      new Error('You cannot buy your own listing'),
+    );
+    const req: any = {
+      user: { uid: 'seller-1' },
+      body: { productId: 'product-1' },
+    };
+    const res = createResponse();
+
+    await createPaymentIntent(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        message: 'Self-purchase is not allowed',
+      }),
+    );
+  });
+});

--- a/src/modules/payment/tests/paymentService.test.ts
+++ b/src/modules/payment/tests/paymentService.test.ts
@@ -65,6 +65,7 @@ describe('PaymentService', () => {
     });
     mockGetProductById.mockResolvedValue({
       id: 'product-1',
+      userId: 'seller-1',
       price: 25,
       number: 1,
       postageSize: 'postage-size-1',
@@ -122,6 +123,29 @@ describe('PaymentService', () => {
         currency: 'GBP',
       }),
     );
+  });
+
+  it('rejects self-purchase before creating a Stripe PaymentIntent', async () => {
+    mockGetProductById.mockResolvedValue({
+      id: 'product-1',
+      user_id: 'user-1',
+      price: 25,
+      number: 1,
+      postageSize: 'postage-size-1',
+    });
+    const service = new PaymentService();
+
+    await expect(
+      service.createPaymentIntentForUserByUid('user-1', {
+        productId: 'product-1',
+        shippingMethodId: '3747',
+        pickupPointId: '13127548',
+        country: 'GB',
+        postalCode: 'SE18 4QH',
+      }),
+    ).rejects.toThrow('You cannot buy your own listing');
+
+    expect(mockCreatePaymentIntentForUser).not.toHaveBeenCalled();
   });
 
   it('verifies a succeeded PaymentIntent and parses trusted metadata', async () => {

--- a/src/modules/products/controllers/productController.ts
+++ b/src/modules/products/controllers/productController.ts
@@ -37,7 +37,11 @@ const sendPaginatedProductsResponse = <T extends { price: number }>(
 export const getAllProducts = async (req: Request, res: Response): Promise<void> => {
     try {
         const productService = ServiceFactory.getProductService();
-        const query = req.query as unknown as ProductListQuery;
+        const user = (req as any).user;
+        const query = {
+            ...(req.query as unknown as ProductListQuery),
+            excludeUserId: user.uid,
+        };
         const result = await productService.getPaginatedProducts(query);
         sendPaginatedProductsResponse(
             res,
@@ -133,7 +137,11 @@ export const getProductWithDetails = async (req: Request, res: Response): Promis
 export const getAllProductsWithDetails = async (req: Request, res: Response): Promise<void> => {
     try {
         const productService = ServiceFactory.getProductService();
-        const query = req.query as unknown as ProductListQuery;
+        const user = (req as any).user;
+        const query = {
+            ...(req.query as unknown as ProductListQuery),
+            excludeUserId: user.uid,
+        };
         const result = await productService.getPaginatedProductsWithDetails(query);
         sendPaginatedProductsResponse(
             res,

--- a/src/modules/products/services/ProductService.ts
+++ b/src/modules/products/services/ProductService.ts
@@ -14,6 +14,7 @@ import { CategoryRepository } from '../../categories/repositories/CategoryReposi
 import { CharityRepository } from '../../charities/repositories/CharityRepository';
 import { PostageSize } from '../../postage-sizes/model/PostageSize';
 import { PostageSizeRepository } from '../../postage-sizes/repositories/PostageSizeRepository';
+import { productBelongsToUser } from '../utils/productOwnership';
 
 const DEFAULT_PRODUCT_PAGE_SIZE = 20;
 const MAX_PRODUCT_PAGE_SIZE = 50;
@@ -431,6 +432,13 @@ export class ProductService {
         query: ProductListQuery,
     ): T[] {
         return products.filter((product) => {
+            if (
+                query.excludeUserId &&
+                productBelongsToUser(product, query.excludeUserId)
+            ) {
+                return false;
+            }
+
             if (query.categoryId && product.categoryId !== query.categoryId) {
                 return false;
             }
@@ -584,6 +592,7 @@ export class ProductService {
             quality: query.quality || '',
             minPrice: query.minPrice ?? null,
             maxPrice: query.maxPrice ?? null,
+            excludeUserId: query.excludeUserId || '',
         });
     }
 
@@ -629,6 +638,7 @@ export interface ProductListQuery extends ProductListFilters {
     limit?: number;
     cursor?: string;
     search?: string;
+    excludeUserId?: string;
 }
 
 export interface PaginatedResult<T> {

--- a/src/modules/products/tests/productController.test.ts
+++ b/src/modules/products/tests/productController.test.ts
@@ -1,0 +1,64 @@
+const mockGetPaginatedProducts = jest.fn();
+const mockGetPaginatedProductsWithDetails = jest.fn();
+
+jest.mock('../services/ServiceFactory', () => ({
+  ServiceFactory: {
+    getProductService: () => ({
+      getPaginatedProducts: mockGetPaginatedProducts,
+      getPaginatedProductsWithDetails: mockGetPaginatedProductsWithDetails,
+    }),
+  },
+}));
+
+import {
+  getAllProducts,
+  getAllProductsWithDetails,
+} from '../controllers/productController';
+
+const createResponse = () => {
+  const res: any = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+};
+
+describe('product feed controllers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const emptyPage = {
+      items: [],
+      limit: 20,
+      nextCursor: null,
+      hasMore: false,
+    };
+    mockGetPaginatedProducts.mockResolvedValue(emptyPage);
+    mockGetPaginatedProductsWithDetails.mockResolvedValue(emptyPage);
+  });
+
+  it.each([
+    ['products', getAllProducts, mockGetPaginatedProducts],
+    [
+      'products with details',
+      getAllProductsWithDetails,
+      mockGetPaginatedProductsWithDetails,
+    ],
+  ])(
+    'scopes the %s feed away from the authenticated seller',
+    async (_name, controller, serviceMethod) => {
+      const req: any = {
+        user: { uid: 'seller-1' },
+        query: { limit: 20, search: 'jumper' },
+      };
+      const res = createResponse();
+
+      await controller(req, res);
+
+      expect(serviceMethod).toHaveBeenCalledWith({
+        limit: 20,
+        search: 'jumper',
+        excludeUserId: 'seller-1',
+      });
+      expect(res.status).toHaveBeenCalledWith(200);
+    },
+  );
+});

--- a/src/modules/products/tests/productService.test.ts
+++ b/src/modules/products/tests/productService.test.ts
@@ -100,6 +100,47 @@ describe('ProductService pagination', () => {
         ).rejects.toThrow('Invalid cursor');
     });
 
+    it('excludes the signed-in seller while filling the requested page', async () => {
+        const ownProduct = createProduct('own-product', '2026-07-13T10:00:00.000Z');
+        const firstOther = {
+            ...createProduct('other-1', '2026-07-13T09:00:00.000Z'),
+            userId: 'seller-2',
+        };
+        const secondOther = {
+            ...createProduct('other-2', '2026-07-13T08:00:00.000Z'),
+            userId: 'seller-3',
+        };
+        const getPageByFilters = jest
+            .fn()
+            .mockResolvedValueOnce({
+                items: [ownProduct, firstOther],
+                hasMore: true,
+            })
+            .mockResolvedValueOnce({
+                items: [secondOther],
+                hasMore: false,
+            });
+
+        const service = new ProductService(
+            { getPageByFilters } as any,
+            productLikeRepo,
+            categoryRepo,
+            charityRepo,
+            postageSizeRepo,
+        );
+
+        const result = await service.getPaginatedProducts({
+            limit: 2,
+            excludeUserId: 'user-1',
+        });
+
+        expect(result.items.map((product) => product.id)).toEqual([
+            'other-1',
+            'other-2',
+        ]);
+        expect(getPageByFilters).toHaveBeenCalledTimes(2);
+    });
+
     it('scopes my-products pagination to the authenticated user', async () => {
         const ownedProduct = createProduct('owned-product', '2026-07-13T10:00:00.000Z');
         const getPageByFilters = jest.fn().mockResolvedValueOnce({

--- a/src/modules/products/utils/productOwnership.ts
+++ b/src/modules/products/utils/productOwnership.ts
@@ -1,0 +1,20 @@
+type ProductOwnershipData = {
+  userId?: unknown;
+  user_id?: unknown;
+};
+
+export const SELF_PURCHASE_ERROR = 'You cannot buy your own listing';
+
+export const productBelongsToUser = (
+  product: ProductOwnershipData,
+  userId: string,
+): boolean => {
+  const sellerId =
+    typeof product.userId === 'string'
+      ? product.userId
+      : typeof product.user_id === 'string'
+        ? product.user_id
+        : null;
+
+  return sellerId === userId;
+};


### PR DESCRIPTION
## What changed

- exclude the authenticated seller from both paginated product feed endpoints, including search and subsequent pages
- resolve ownership from current `userId` and legacy `user_id` records
- reject self-purchase before creating a Stripe PaymentIntent
- reject self-purchase again during paid order creation and inside the inventory transaction
- return a clear 403 response from payment and order endpoints

## Why

Authenticated feeds did not scope out the seller's own listings. Checkout also trusted the selected product without comparing its seller to the authenticated buyer, allowing a seller to begin and potentially complete a purchase of their own listing.

## Impact

Buyers keep full feed pages without seeing their own listings. Self-purchase is blocked at every trusted backend boundary, even if the app guard is bypassed or an older product record uses `user_id`.

## Checks

- `NODE_ENV=production FIREBASE_PROJECT_ID=cherry-test FIREBASE_API_KEY=test npm test -- --runInBand` (43 tests passed)
- `npm run build`
- `git diff --check`

## App safeguard

Paired with Cherry-CIC/MVP#466 for client-side feed filtering and checkout prevention.